### PR TITLE
fix(issue-164): Fix groupIdsRefs/groupIdsSelector in groups.user.keycloak.crossplane.io

### DIFF
--- a/apis/user/v1alpha1/zz_generated.resolvers.go
+++ b/apis/user/v1alpha1/zz_generated.resolvers.go
@@ -25,7 +25,27 @@ func (mg *Groups) ResolveReferences(ctx context.Context, c client.Reader) error 
 	r := reference.NewAPIResolver(c, mg)
 
 	var rsp reference.ResolutionResponse
+	var mrsp reference.MultiResolutionResponse
 	var err error
+	{
+		m, l, err = apisresolver.GetManagedResource("group.keycloak.crossplane.io", "v1alpha1", "Group", "GroupList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+			CurrentValues: reference.FromPtrValues(mg.Spec.ForProvider.GroupIds),
+			Extract:       reference.ExternalName(),
+			References:    mg.Spec.ForProvider.GroupIdsRefs,
+			Selector:      mg.Spec.ForProvider.GroupIdsSelector,
+			To:            reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.GroupIds")
+	}
+	mg.Spec.ForProvider.GroupIds = reference.ToPtrValues(mrsp.ResolvedValues)
+	mg.Spec.ForProvider.GroupIdsRefs = mrsp.ResolvedReferences
 	{
 		m, l, err = apisresolver.GetManagedResource("realm.keycloak.crossplane.io", "v1alpha1", "Realm", "RealmList")
 		if err != nil {
@@ -64,6 +84,25 @@ func (mg *Groups) ResolveReferences(ctx context.Context, c client.Reader) error 
 	}
 	mg.Spec.ForProvider.UserID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.UserIDRef = rsp.ResolvedReference
+	{
+		m, l, err = apisresolver.GetManagedResource("group.keycloak.crossplane.io", "v1alpha1", "Group", "GroupList")
+		if err != nil {
+			return errors.Wrap(err, "failed to get the reference target managed resource and its list for reference resolution")
+		}
+
+		mrsp, err = r.ResolveMultiple(ctx, reference.MultiResolutionRequest{
+			CurrentValues: reference.FromPtrValues(mg.Spec.InitProvider.GroupIds),
+			Extract:       reference.ExternalName(),
+			References:    mg.Spec.InitProvider.GroupIdsRefs,
+			Selector:      mg.Spec.InitProvider.GroupIdsSelector,
+			To:            reference.To{List: l, Managed: m},
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.GroupIds")
+	}
+	mg.Spec.InitProvider.GroupIds = reference.ToPtrValues(mrsp.ResolvedValues)
+	mg.Spec.InitProvider.GroupIdsRefs = mrsp.ResolvedReferences
 	{
 		m, l, err = apisresolver.GetManagedResource("realm.keycloak.crossplane.io", "v1alpha1", "Realm", "RealmList")
 		if err != nil {

--- a/apis/user/v1alpha1/zz_groups_types.go
+++ b/apis/user/v1alpha1/zz_groups_types.go
@@ -19,14 +19,15 @@ type GroupsInitParameters struct {
 	Exhaustive *bool `json:"exhaustive,omitempty" tf:"exhaustive,omitempty"`
 
 	// A list of group IDs that the user is member of.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-keycloak/apis/group/v1alpha1.Group
 	// +listType=set
 	GroupIds []*string `json:"groupIds,omitempty" tf:"group_ids,omitempty"`
 
-	// References to  to populate groupIds.
+	// References to Group in group to populate groupIds.
 	// +kubebuilder:validation:Optional
 	GroupIdsRefs []v1.Reference `json:"groupIdsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of  to populate groupIds.
+	// Selector for a list of Group in group to populate groupIds.
 	// +kubebuilder:validation:Optional
 	GroupIdsSelector *v1.Selector `json:"groupIdsSelector,omitempty" tf:"-"`
 
@@ -80,15 +81,16 @@ type GroupsParameters struct {
 	Exhaustive *bool `json:"exhaustive,omitempty" tf:"exhaustive,omitempty"`
 
 	// A list of group IDs that the user is member of.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-keycloak/apis/group/v1alpha1.Group
 	// +kubebuilder:validation:Optional
 	// +listType=set
 	GroupIds []*string `json:"groupIds,omitempty" tf:"group_ids,omitempty"`
 
-	// References to  to populate groupIds.
+	// References to Group in group to populate groupIds.
 	// +kubebuilder:validation:Optional
 	GroupIdsRefs []v1.Reference `json:"groupIdsRefs,omitempty" tf:"-"`
 
-	// Selector for a list of  to populate groupIds.
+	// Selector for a list of Group in group to populate groupIds.
 	// +kubebuilder:validation:Optional
 	GroupIdsSelector *v1.Selector `json:"groupIdsSelector,omitempty" tf:"-"`
 

--- a/config/user/config.go
+++ b/config/user/config.go
@@ -20,7 +20,9 @@ func Configure(p *config.Provider) {
 			TerraformName: "keycloak_user",
 		}
 
-		r.References["group_ids"] = config.Reference{}
+		r.References["group_ids"] = config.Reference{
+			TerraformName: "keycloak_group",
+		}
 	})
 
 	p.AddResourceConfigurator("keycloak_user_roles", func(r *config.Resource) {

--- a/examples-generated/user/v1alpha1/groups.yaml
+++ b/examples-generated/user/v1alpha1/groups.yaml
@@ -8,8 +8,8 @@ metadata:
   name: user-groups
 spec:
   forProvider:
-    groupIds:
-    - ${keycloak_group.group.id}
+    groupIdsRefs:
+    - name: group
     realmIdSelector:
       matchLabels:
         testing.upbound.io/example-name: realm

--- a/package/crds/user.keycloak.crossplane.io_groups.yaml
+++ b/package/crds/user.keycloak.crossplane.io_groups.yaml
@@ -84,7 +84,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   groupIdsRefs:
-                    description: References to  to populate groupIds.
+                    description: References to Group in group to populate groupIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -121,7 +121,8 @@ spec:
                       type: object
                     type: array
                   groupIdsSelector:
-                    description: Selector for a list of  to populate groupIds.
+                    description: Selector for a list of Group in group to populate
+                      groupIds.
                     properties:
                       matchControllerRef:
                         description: |-
@@ -341,7 +342,7 @@ spec:
                     type: array
                     x-kubernetes-list-type: set
                   groupIdsRefs:
-                    description: References to  to populate groupIds.
+                    description: References to Group in group to populate groupIds.
                     items:
                       description: A Reference to a named object.
                       properties:
@@ -378,7 +379,8 @@ spec:
                       type: object
                     type: array
                   groupIdsSelector:
-                    description: Selector for a list of  to populate groupIds.
+                    description: Selector for a list of Group in group to populate
+                      groupIds.
                     properties:
                       matchControllerRef:
                         description: |-


### PR DESCRIPTION
This adds the `keycloak_group` terraform name to the `group_ids` reference so that groupIds can be resolved at runtime.

Fixes #164 
