### PR TITLE
Fixes wrong provider name in error message

### DIFF
--- a/internal/clients/keycloak.go
+++ b/internal/clients/keycloak.go
@@ -113,7 +113,7 @@ func configureNoForkKeycloakClient(ctx context.Context, ps *terraform.Setup) err
 
 	diags := cb.Configure(ctx, terraformSDK.NewResourceConfigRaw(ps.Configuration))
 	if diags.HasError() {
-		return fmt.Errorf("failed to configure the Grafana provider: %v", diags)
+		return fmt.Errorf("failed to configure the Keycloak provider: %v", diags)
 	}
 
 	ps.Meta = cb.Meta()


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This PR fixes displaying the wrong provider name (grafana -> keycloak) in the error message, when an error occurs with the provider/providerConfig.


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
