### PR TITLE
Improvement/update-linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,9 @@
+run:
+  # Timeout for analysis, e.g. 30s, 5m, 5m30s.
+  # If the value is lower or equal to 0, the timeout is disabled.
+  # Default: 1m
+  timeout: 10m
+
 output:
   # The formats used to render issues.
   # Formats:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,30 @@
 output:
-  # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
+  # The formats used to render issues.
+  # Formats:
+  # - `colored-line-number`
+  # - `line-number`
+  # - `json`
+  # - `colored-tab`
+  # - `tab`
+  # - `html`
+  # - `checkstyle`
+  # - `code-climate`
+  # - `junit-xml`
+  # - `junit-xml-extended`
+  # - `github-actions`
+  # - `teamcity`
+  # - `sarif`
+  # Output path can be either `stdout`, `stderr` or path to the file to write to.
+  #
+  # For the CLI flag (`--out-format`), multiple formats can be specified by separating them by comma.
+  # The output can be specified for each of them by separating format name and path by colon symbol.
+  # Example: "--out-format=checkstyle:report.xml,json:stdout,colored-line-number"
+  # The CLI flag (`--out-format`) override the configuration file.
+  #
+  # Default:
+  #   formats:
+  #     - format: colored-line-number
+  #       path: stdout
   formats:
     - format: colored-line-number
 
@@ -13,14 +38,13 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: false
 
-    # comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
+    # List of functions to exclude from checking, where each entry is a single function to exclude.
+    # See https://github.com/kisielk/errcheck#excluding-functions for details.
     exclude-functions:
       - fmt:.*,io/ioutil:^Read.*
 
   govet:
-    # report about shadowed variables
+    # Check for possible unintended shadowing of variables.
     enable:
       - shadow
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,7 @@
-run:
-  deadline: 10m
-
-  skip-files:
-  - "zz_\\..+\\.go$"
-
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
 
 linters-settings:
   errcheck:
@@ -18,18 +13,22 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: false
 
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
+    # comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").
     # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    exclude-functions:
+      - fmt:.*,io/ioutil:^Read.*
 
   govet:
     # report about shadowed variables
-    check-shadowing: false
+    enable:
+      - shadow
 
-  golint:
-    # minimal confidence for issues, default is 0.8
-    min-confidence: 0.8
+  revive:
+    # Sets the default failure confidence.
+    # This means that linting errors with less than 0.8 confidence will be ignored.
+    # Default: 0.8
+    confidence: 0.8
 
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
@@ -43,10 +42,6 @@ linters-settings:
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 10
-
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
 
   dupl:
     # tokens count to trigger issue, 150 by default
@@ -67,7 +62,7 @@ linters-settings:
     # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
     # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
     # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
+    exported-fields-are-used: false
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
@@ -104,19 +99,22 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
     - govet
     - gocyclo
     - gocritic
-    - interfacer
     - goconst
     - goimports
     - gofmt  # We enable this as well as goimports for its simplify mode.
     - prealloc
-    - golint
     - unconvert
     - misspell
     - nakedret
+    - gosimple
+    - staticcheck
+    - unused
+    - revive
+    - gosec
+    - ineffassign
 
   presets:
     - bugs
@@ -173,7 +171,8 @@ issues:
       linters:
       - gosec
       - gas
-
+  exclude-files:
+    - "zz_\\..+\\.go$"
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
   # excluded by default patterns execute `golangci-lint run --help`.
@@ -189,7 +188,7 @@ issues:
   new: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export TERRAFORM_DOCS_PATH ?= docs/resources
 export TERRAFORM_FILE_MIRROR ?= .terraform.d/plugins
 export TERRAFORM_FILE_MIRROR_REPO ?= ${TERRAFORM_FILE_MIRROR}/registry.terraform.io
 
-export GOLANGCILINT_VERSION ?= 1.57.2
+export GOLANGCILINT_VERSION ?= 1.64.6
 
 PLATFORMS ?= linux_amd64 linux_arm64
 


### PR DESCRIPTION
running `golangci-lint run` resulted in some deprecation warnings
I updated the lint config keeping the configuration as consistent as possible

### Removed linters

- megacheck
- interfacer
- golint

### Added linters

- gosimple
- staticcheck
- unused
- revive
- gosec
- ineffassign

### How has this code been tested

running `golangci-lint run` does not show any warning. Currently there are no lint issues either.
