### PR TITLE
fix: add support for ClientScope in GroupMembershipProtocolMapper

### DIFF
--- a/config/openidgroup/config.go
+++ b/config/openidgroup/config.go
@@ -2,6 +2,7 @@ package openidgroup
 
 import (
 	"context"
+
 	"github.com/crossplane-contrib/provider-keycloak/config/lookup"
 	"github.com/crossplane/upjet/pkg/config"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak"
@@ -20,7 +21,8 @@ func Configure(p *config.Provider) {
 }
 
 var identifyingPropertiesLookup = lookup.IdentifyingPropertiesLookupConfig{
-	RequiredParameters:           []string{"realm_id", "client_id", "name"},
+	RequiredParameters:           []string{"realm_id", "name"},
+	OptionalParameters:           []string{"client_id", "client_scope_id"},
 	GetIDByExternalName:          getIDByExternalName,
 	GetIDByIdentifyingProperties: getIDByIdentifyingProperties,
 }
@@ -29,7 +31,7 @@ var identifyingPropertiesLookup = lookup.IdentifyingPropertiesLookupConfig{
 var IdentifierFromIdentifyingProperties = lookup.BuildIdentifyingPropertiesLookup(identifyingPropertiesLookup)
 
 func getIDByExternalName(ctx context.Context, id string, parameters map[string]any, kcClient *keycloak.KeycloakClient) (string, error) {
-	found, err := kcClient.GetOpenIdGroupMembershipProtocolMapper(ctx, parameters["realm_id"].(string), parameters["client_id"].(string), "", id)
+	found, err := kcClient.GetOpenIdGroupMembershipProtocolMapper(ctx, parameters["realm_id"].(string), parameters["client_id"].(string), parameters["client_scope_id"].(string), id)
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +39,7 @@ func getIDByExternalName(ctx context.Context, id string, parameters map[string]a
 }
 
 func getIDByIdentifyingProperties(ctx context.Context, parameters map[string]any, kcClient *keycloak.KeycloakClient) (string, error) {
-	found, err := kcClient.GetGenericProtocolMappers(ctx, parameters["realm_id"].(string), parameters["client_id"].(string))
+	found, err := lookup.GetGenericProtocolMappers(kcClient, ctx, parameters["realm_id"].(string), parameters["client_id"].(string), parameters["client_scope_id"].(string))
 	if err != nil {
 		return "", err
 	}

--- a/config/provider.go
+++ b/config/provider.go
@@ -135,6 +135,11 @@ func KnownReferencers() config.ResourceOption { //nolint:gocyclo
 					TerraformName: "keycloak_openid_client",
 					Extractor:     common.PathUUIDExtractor,
 				}
+			case "client_scope_id":
+				r.References["client_scope_id"] = config.Reference{
+					TerraformName: "keycloak_openid_client_scope",
+					Extractor:     common.PathUUIDExtractor,
+				}
 			case "service_account_user_id":
 				r.References["service_account_user_id"] = config.Reference{
 					TerraformName:     "keycloak_openid_client",

--- a/dev/demos/basic/044-oidc-group-membership-protocol-mapper.yaml
+++ b/dev/demos/basic/044-oidc-group-membership-protocol-mapper.yaml
@@ -1,7 +1,7 @@
 apiVersion: openidgroup.keycloak.crossplane.io/v1alpha1
 kind: GroupMembershipProtocolMapper
 metadata:
-  name: my-group-membership
+  name: openid-client-group-membership-protocol-mapper
 spec:
   providerConfigRef:
     name: "keycloak-provider-config"
@@ -10,6 +10,22 @@ spec:
     name: "my-mapper"
     clientIdRef:
       name: "test"
+    realmIdRef:
+      name: "dev"
+    claimName: "test"
+---
+apiVersion: openidgroup.keycloak.crossplane.io/v1alpha1
+kind: GroupMembershipProtocolMapper
+metadata:
+  name: openid-client-scope-group-membership-protocol-mapper
+spec:
+  providerConfigRef:
+    name: "keycloak-provider-config"
+  deletionPolicy: Delete
+  forProvider:
+    name: "my-mapper"
+    clientScopeIdRef:
+      name: "openid-client-scope"
     realmIdRef:
       name: "dev"
     claimName: "test"


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Allow the use of clientScopeId in GroupMembershipProtocolMapper

Fixes #305 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Creation of the resource mentioned in #305 was successful. 

This code is published at `xpkg.upbound.io/zadkiel/provider-keycloak:v3.0.4`. 

[contribution process]: https://git.io/fj2m9
