### PR TITLE
fix: typos in adapted code

### DIFF
--- a/apis/cluster/v1beta1/types.go
+++ b/apis/cluster/v1beta1/types.go
@@ -33,12 +33,12 @@ type ProviderConfigStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A ProviderConfig configures a Vault provider.
+// A ProviderConfig configures a keycloak provider.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,vault}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,keycloak}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -63,7 +63,7 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,vault}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,keycloak}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/namespaced/v1beta1/types.go
+++ b/apis/namespaced/v1beta1/types.go
@@ -44,12 +44,12 @@ type ProviderConfigStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A ProviderConfig configures a Vault provider.
+// A ProviderConfig configures a keycloak provider.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:resource:scope=Namespaced,categories={crossplane,provider,vault}
+// +kubebuilder:resource:scope=Namespaced,categories={crossplane,provider,keycloak}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -74,7 +74,7 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Namespaced,categories={crossplane,provider,vault}
+// +kubebuilder:resource:scope=Namespaced,categories={crossplane,provider,keycloak}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -93,12 +93,12 @@ type ProviderConfigUsageList struct {
 
 // +kubebuilder:object:root=true
 
-// A ClusterProviderConfig configures a Vault provider.
+// A ClusterProviderConfig configures a keycloak provider.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,vault}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,keycloak}
 type ClusterProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -62,7 +62,7 @@ func deprecationAction(flagName string) kingpin.Action {
 
 func main() {
 	var (
-		app                     = kingpin.New(filepath.Base(os.Args[0]), "Terraform based Crossplane provider for Vault").DefaultEnvars()
+		app                     = kingpin.New(filepath.Base(os.Args[0]), "Terraform based Crossplane provider for keycloak").DefaultEnvars()
 		debug                   = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncPeriod              = app.Flag("sync", "Controller manager sync period such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
 		pollInterval            = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("10m").Duration()
@@ -91,7 +91,7 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	zl := zap.New(zap.UseDevMode(*debug))
-	log := logging.NewLogrLogger(zl.WithName("provider-vault"))
+	log := logging.NewLogrLogger(zl.WithName("provider-keycloak"))
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is
 		// *very* verbose even at info level, so we only provide it a real
@@ -218,12 +218,12 @@ func main() {
 		optsCluster.Gate = crdGate
 		optsNamespaced.Gate = crdGate
 		kingpin.FatalIfError(customresourcesgate.Setup(mgr, optsNamespaced.Options), "Cannot setup CRD gate")
-		kingpin.FatalIfError(controllerCluster.SetupGated(mgr, optsCluster), "Cannot setup Vault controllers")
-		kingpin.FatalIfError(controllerNamespaced.SetupGated(mgr, optsNamespaced), "Cannot setup Vault controllers")
+		kingpin.FatalIfError(controllerCluster.SetupGated(mgr, optsCluster), "Cannot setup Keycloak controllers")
+		kingpin.FatalIfError(controllerNamespaced.SetupGated(mgr, optsNamespaced), "Cannot setup Keycloak controllers")
 	} else {
 		log.Info("Provider has missing RBAC permissions for watching CRDs, controller SafeStart capability will be disabled")
-		kingpin.FatalIfError(controllerCluster.Setup(mgr, optsCluster), "Cannot setup Vault controllers")
-		kingpin.FatalIfError(controllerNamespaced.Setup(mgr, optsNamespaced), "Cannot setup Vault controllers")
+		kingpin.FatalIfError(controllerCluster.Setup(mgr, optsCluster), "Cannot setup Keycloak controllers")
+		kingpin.FatalIfError(controllerNamespaced.Setup(mgr, optsNamespaced), "Cannot setup Keycloak controllers")
 	}
 
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	k8s.io/client-go v0.34.1
 	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/controller-tools v0.18.0
-
 )
 
 require (

--- a/package/crds/keycloak.crossplane.io_providerconfigs.yaml
+++ b/package/crds/keycloak.crossplane.io_providerconfigs.yaml
@@ -11,7 +11,7 @@ spec:
     categories:
     - crossplane
     - provider
-    - vault
+    - keycloak
     kind: ProviderConfig
     listKind: ProviderConfigList
     plural: providerconfigs
@@ -29,7 +29,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfig configures a Vault provider.
+        description: A ProviderConfig configures a keycloak provider.
         properties:
           apiVersion:
             description: |-

--- a/package/crds/keycloak.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/keycloak.crossplane.io_providerconfigusages.yaml
@@ -11,7 +11,7 @@ spec:
     categories:
     - crossplane
     - provider
-    - vault
+    - keycloak
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages

--- a/package/crds/keycloak.m.crossplane.io_clusterproviderconfigs.yaml
+++ b/package/crds/keycloak.m.crossplane.io_clusterproviderconfigs.yaml
@@ -11,7 +11,7 @@ spec:
     categories:
     - crossplane
     - provider
-    - vault
+    - keycloak
     kind: ClusterProviderConfig
     listKind: ClusterProviderConfigList
     plural: clusterproviderconfigs
@@ -29,7 +29,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ClusterProviderConfig configures a Vault provider.
+        description: A ClusterProviderConfig configures a keycloak provider.
         properties:
           apiVersion:
             description: |-

--- a/package/crds/keycloak.m.crossplane.io_providerconfigs.yaml
+++ b/package/crds/keycloak.m.crossplane.io_providerconfigs.yaml
@@ -11,7 +11,7 @@ spec:
     categories:
     - crossplane
     - provider
-    - vault
+    - keycloak
     kind: ProviderConfig
     listKind: ProviderConfigList
     plural: providerconfigs
@@ -29,7 +29,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfig configures a Vault provider.
+        description: A ProviderConfig configures a keycloak provider.
         properties:
           apiVersion:
             description: |-

--- a/package/crds/keycloak.m.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/keycloak.m.crossplane.io_providerconfigusages.yaml
@@ -11,7 +11,7 @@ spec:
     categories:
     - crossplane
     - provider
-    - vault
+    - keycloak
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages


### PR DESCRIPTION
### Description of your changes
Just fixing some naming problems, which sliped through while adapting provider-vault's code