### PR TITLE
chore: update OWNERS.md with current maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,7 +1,7 @@
 # OWNERS
 
-This page lists all maintainers for **this** repository. Each repository in the [Upbound
-organization](https://github.com/upbound/) will list their repository maintainers in their own
+This page lists all maintainers for **this** repository. Each repository in the [crossplane-contrib
+organization](https://github.com/crossplane-contrib/) will list their repository maintainers in their own
 `OWNERS.md` file.
 
 
@@ -10,6 +10,7 @@ organization](https://github.com/upbound/) will list their repository maintainer
 * [Breee](https://github.com/Breee)
 * [haarchri](https://github.com/haarchri)
 * [denniskniep](https://github.com/denniskniep)
+* [smoehrle](https://github.com/smoehrle)
 
 
 See [CODEOWNERS](./CODEOWNERS) for automatic PR assignment.


### PR DESCRIPTION
### Description of your changes

This PR updates the OWNERS.md file with the current maintainer team to match what I see in github permissions. If @smoehrle should not be a maintainer then let's please remove their permissions.

It also updates the organization name mentioned to crossplane-contrib.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

[contribution process]: https://git.io/fj2m9
