### PR TITLE
fix(logs): restoring controller-runtime logger to a no-op logger by default

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"time"
@@ -92,6 +93,13 @@ func main() {
 
 	zl := zap.New(zap.UseDevMode(*debug))
 	log := logging.NewLogrLogger(zl.WithName("provider-keycloak"))
+
+	// Setting the controller-runtime logger to a no-op logger by default,
+	// unless debug mode is enabled. This is because the controller-runtime
+	// logger is *very* verbose even at info level. This is not really needed,
+	// but otherwise we get a warning from the controller-runtime.
+	ctrl.SetLogger(zap.New(zap.WriteTo(io.Discard)))
+
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is
 		// *very* verbose even at info level, so we only provide it a real


### PR DESCRIPTION
### Description of your changes

Restoring controller-runtime logger to a no-op logger by default.
Fixes #454

