### PR TITLE
fix argocd install with server side apply

### DIFF
--- a/dev/setup_dev_environment.sh
+++ b/dev/setup_dev_environment.sh
@@ -193,7 +193,7 @@ fi
 
 echo "########### Installing ArgoCD ###########"
 $kubectl_cmd create namespace argocd || true
-$kubectl_cmd apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+$kubectl_cmd apply --server-side=true -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 echo "* Exposing ArgoCD"
 $kubectl_cmd patch svc argocd-server -n argocd -p '{"spec": {"type": "LoadBalancer"}}'
 


### PR DESCRIPTION
### Description of your changes

Install ArgoCD with server side apply in the `setup_dev_environment.sh`

Fixes CI E2E Test setup

>########### Installing ArgoCD ###########
> ...
>The CustomResourceDefinition "applicationsets.argoproj.io" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

`./dev/setup_dev_environment.sh`

[contribution process]: https://git.io/fj2m9
