### PR TITLE
Auto-recover from stale cross-resource references

### DIFF
--- a/dev/test/stale-ref-recovery.sh
+++ b/dev/test/stale-ref-recovery.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# End-to-end test for stale-reference recovery
+# (internal/clients/stalerefs).
+#
+# Scenario:
+#   1. Apply a Realm + a "target" Role + a Role + a RoleMapper that references
+#      the target Role via roleIdRef.
+#   2. Wait for everything Synced=True.
+#   3. Capture the resolved spec.forProvider.roleId on the RoleMapper (this is
+#      the Keycloak UUID).
+#   4. Delete the target Role directly via the Keycloak Admin API (bypassing
+#      the K8s reconciler so the local Role MR's status doesn't auto-update).
+#   5. Re-create the target Role with the same name. The new Keycloak Role has
+#      a fresh UUID.
+#   6. Watch the Role MR's reconciler observe its own external resource and
+#      pick up the new UUID into status.atProvider.id.
+#   7. Watch the RoleMapper's reconciler hit a 404 from Keycloak, the provider
+#      clear spec.forProvider.roleId via stalerefs.MaybeRecover, and the
+#      runtime resolver repopulate it with the new UUID. Synced=True returns.
+#   8. Assert: the new resolved roleId != the original.
+#
+# Usage:
+#   dev/test/stale-ref-recovery.sh
+#
+# Requires the dev environment from dev/setup_dev_environment.sh to be
+# running. KEYCLOAK_IP, KEYCLOAK_PORT, KEYCLOAK_USER, KEYCLOAK_PASSWORD must
+# be exported (the setup script exports them).
+
+set -euo pipefail
+
+: "${KEYCLOAK_IP:?KEYCLOAK_IP not set — source dev/setup_dev_environment.sh first}"
+: "${KEYCLOAK_PORT:?KEYCLOAK_PORT not set}"
+: "${KEYCLOAK_USER:=admin}"
+: "${KEYCLOAK_PASSWORD:=admin}"
+
+KC_BASE="http://${KEYCLOAK_IP}:${KEYCLOAK_PORT}"
+REALM="dev"
+TARGET_ROLE="stale-ref-target-role"
+RM_NAME="stale-ref-rolemapper"
+SOURCE_CLIENT="test"
+
+log() { printf "==> %s\n" "$*"; }
+die() { printf "FAIL: %s\n" "$*" >&2; exit 1; }
+
+kc_token() {
+  curl -fsS -X POST "${KC_BASE}/realms/master/protocol/openid-connect/token" \
+    -d "grant_type=password" \
+    -d "client_id=admin-cli" \
+    -d "username=${KEYCLOAK_USER}" \
+    -d "password=${KEYCLOAK_PASSWORD}" | jq -r '.access_token'
+}
+
+kc_role_uuid() {
+  local token=$1 name=$2
+  curl -fsS -H "Authorization: Bearer ${token}" \
+    "${KC_BASE}/admin/realms/${REALM}/roles/${name}" | jq -r '.id'
+}
+
+kc_delete_role() {
+  local token=$1 name=$2
+  curl -fsS -X DELETE -H "Authorization: Bearer ${token}" \
+    "${KC_BASE}/admin/realms/${REALM}/roles/${name}"
+}
+
+kc_create_role() {
+  local token=$1 name=$2
+  curl -fsS -X POST -H "Authorization: Bearer ${token}" \
+    -H "Content-Type: application/json" \
+    "${KC_BASE}/admin/realms/${REALM}/roles" \
+    -d "{\"name\":\"${name}\"}"
+}
+
+cleanup() {
+  log "Cleanup"
+  kubectl delete -f - --ignore-not-found <<EOF || true
+apiVersion: client.keycloak.crossplane.io/v1alpha1
+kind: RoleMapper
+metadata: {name: ${RM_NAME}}
+---
+apiVersion: role.keycloak.crossplane.io/v1alpha1
+kind: Role
+metadata: {name: ${TARGET_ROLE}}
+EOF
+}
+trap cleanup EXIT
+
+log "Applying Role + RoleMapper"
+kubectl apply -f - <<EOF
+apiVersion: role.keycloak.crossplane.io/v1alpha1
+kind: Role
+metadata:
+  name: ${TARGET_ROLE}
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    realmId: ${REALM}
+    name: ${TARGET_ROLE}
+  providerConfigRef:
+    name: keycloak-provider-config
+---
+apiVersion: client.keycloak.crossplane.io/v1alpha1
+kind: RoleMapper
+metadata:
+  name: ${RM_NAME}
+spec:
+  deletionPolicy: Delete
+  providerConfigRef:
+    name: keycloak-provider-config
+  forProvider:
+    realmId: ${REALM}
+    clientIdRef:
+      name: ${SOURCE_CLIENT}
+    roleIdRef:
+      name: ${TARGET_ROLE}
+EOF
+
+log "Waiting for Role to be Synced=True"
+kubectl wait role.role.keycloak.crossplane.io/${TARGET_ROLE} \
+  --for=condition=Synced=True --timeout=120s
+
+log "Waiting for RoleMapper to be Synced=True"
+kubectl wait rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
+  --for=condition=Synced=True --timeout=120s
+
+ORIGINAL_ROLE_ID=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
+  -o jsonpath='{.spec.forProvider.roleId}')
+log "Original resolved roleId = ${ORIGINAL_ROLE_ID}"
+
+[[ -n "${ORIGINAL_ROLE_ID}" ]] || die "RoleMapper.spec.forProvider.roleId is empty after Synced"
+
+log "Deleting the Keycloak Role directly via Admin API (bypassing crossplane)"
+TOKEN=$(kc_token)
+kc_delete_role "${TOKEN}" "${TARGET_ROLE}"
+
+log "Recreating the Keycloak Role with the same name (will have a fresh UUID)"
+kc_create_role "${TOKEN}" "${TARGET_ROLE}"
+NEW_KC_UUID=$(kc_role_uuid "${TOKEN}" "${TARGET_ROLE}")
+log "New Keycloak UUID = ${NEW_KC_UUID}"
+
+[[ "${NEW_KC_UUID}" != "${ORIGINAL_ROLE_ID}" ]] \
+  || die "expected new Keycloak UUID to differ from original"
+
+log "Waiting up to 3m for the RoleMapper to recover its reference"
+deadline=$(( $(date +%s) + 180 ))
+while (( $(date +%s) < deadline )); do
+  current=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
+    -o jsonpath='{.spec.forProvider.roleId}' 2>/dev/null || true)
+  synced=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
+    -o jsonpath='{.status.conditions[?(@.type=="Synced")].status}' 2>/dev/null || true)
+  if [[ "${current}" == "${NEW_KC_UUID}" && "${synced}" == "True" ]]; then
+    log "PASS: roleId rewritten to new UUID and Synced=True"
+    log "  before: ${ORIGINAL_ROLE_ID}"
+    log "  after:  ${current}"
+
+    anno=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
+      -o jsonpath='{.metadata.annotations.provider-keycloak\.crossplane\.io/stale-ref-recovery-at-generation}' \
+      2>/dev/null || true)
+    if [[ -n "${anno}" ]]; then
+      log "  recovery annotation set to generation ${anno}"
+    fi
+    exit 0
+  fi
+  sleep 5
+done
+
+die "RoleMapper did not recover within timeout. Last roleId=${current:-<empty>} synced=${synced:-<unknown>}"

--- a/dev/test/stale-ref-recovery.sh
+++ b/dev/test/stale-ref-recovery.sh
@@ -1,31 +1,29 @@
 #!/usr/bin/env bash
 #
-# End-to-end test for stale-reference recovery
-# (internal/clients/stalerefs).
+# Regression test for stale-reference recovery (internal/clients/stalerefs).
 #
-# Scenario:
-#   1. Apply a Realm + a "target" Role + a Role + a RoleMapper that references
-#      the target Role via roleIdRef.
-#   2. Wait for everything Synced=True.
-#   3. Capture the resolved spec.forProvider.roleId on the RoleMapper (this is
-#      the Keycloak UUID).
-#   4. Delete the target Role directly via the Keycloak Admin API (bypassing
-#      the K8s reconciler so the local Role MR's status doesn't auto-update).
-#   5. Re-create the target Role with the same name. The new Keycloak Role has
-#      a fresh UUID.
-#   6. Watch the Role MR's reconciler observe its own external resource and
-#      pick up the new UUID into status.atProvider.id.
-#   7. Watch the RoleMapper's reconciler hit a 404 from Keycloak, the provider
-#      clear spec.forProvider.roleId via stalerefs.MaybeRecover, and the
-#      runtime resolver repopulate it with the new UUID. Synced=True returns.
-#   8. Assert: the new resolved roleId != the original.
+# What it proves:
+#   When a Keycloak object referenced by another managed resource is deleted
+#   and recreated out-of-band (so its UUID changes), the provider clears the
+#   stored stale UUID on spec.forProvider and the runtime resolver
+#   repopulates it with the new one. Without this fix, the dependent resource
+#   stays Synced=False with a 404 from Keycloak forever.
 #
-# Usage:
-#   dev/test/stale-ref-recovery.sh
+# Scenario (self-contained — creates its own Realm, Client, Role, RoleMapper):
+#   1. Apply Realm, Client, target Role and a RoleMapper that references both.
+#   2. Wait for everything Synced=True. Capture the resolved roleId.
+#   3. Delete the Role directly via the Keycloak Admin API (bypasses
+#      crossplane so the K8s Role MR's reconciler discovers the deletion the
+#      hard way).
+#   4. Re-create the Role with the same name (fresh UUID in Keycloak).
+#   5. Wait for the RoleMapper to recover: spec.forProvider.roleId should
+#      transition to the new UUID and Synced=True should return.
+#   6. Assert: new UUID != original, and the recovery annotation is set.
 #
-# Requires the dev environment from dev/setup_dev_environment.sh to be
-# running. KEYCLOAK_IP, KEYCLOAK_PORT, KEYCLOAK_USER, KEYCLOAK_PASSWORD must
-# be exported (the setup script exports them).
+# Prerequisites:
+#   - dev/setup_dev_environment.sh has been run (kind cluster + Keycloak +
+#     provider-keycloak deployed). Exports KEYCLOAK_IP and KEYCLOAK_PORT.
+#   - jq, curl, kubectl available.
 
 set -euo pipefail
 
@@ -35,10 +33,13 @@ set -euo pipefail
 : "${KEYCLOAK_PASSWORD:=admin}"
 
 KC_BASE="http://${KEYCLOAK_IP}:${KEYCLOAK_PORT}"
-REALM="dev"
-TARGET_ROLE="stale-ref-target-role"
-RM_NAME="stale-ref-rolemapper"
-SOURCE_CLIENT="test"
+
+# Unique suffix so reruns and parallel runs don't collide.
+SUFFIX="${SUFFIX:-$(date +%s)}"
+REALM="staleref-${SUFFIX}"
+CLIENT="staleref-client-${SUFFIX}"
+TARGET_ROLE="staleref-role-${SUFFIX}"
+RM_NAME="staleref-rolemapper-${SUFFIX}"
 
 log() { printf "==> %s\n" "$*"; }
 die() { printf "FAIL: %s\n" "$*" >&2; exit 1; }
@@ -52,41 +53,62 @@ kc_token() {
 }
 
 kc_role_uuid() {
-  local token=$1 name=$2
+  local token=$1
   curl -fsS -H "Authorization: Bearer ${token}" \
-    "${KC_BASE}/admin/realms/${REALM}/roles/${name}" | jq -r '.id'
+    "${KC_BASE}/admin/realms/${REALM}/roles/${TARGET_ROLE}" | jq -r '.id'
 }
 
 kc_delete_role() {
-  local token=$1 name=$2
+  local token=$1
   curl -fsS -X DELETE -H "Authorization: Bearer ${token}" \
-    "${KC_BASE}/admin/realms/${REALM}/roles/${name}"
+    "${KC_BASE}/admin/realms/${REALM}/roles/${TARGET_ROLE}"
 }
 
 kc_create_role() {
-  local token=$1 name=$2
+  local token=$1
   curl -fsS -X POST -H "Authorization: Bearer ${token}" \
     -H "Content-Type: application/json" \
     "${KC_BASE}/admin/realms/${REALM}/roles" \
-    -d "{\"name\":\"${name}\"}"
+    -d "{\"name\":\"${TARGET_ROLE}\"}" > /dev/null
 }
 
 cleanup() {
   log "Cleanup"
-  kubectl delete -f - --ignore-not-found <<EOF || true
-apiVersion: client.keycloak.crossplane.io/v1alpha1
-kind: RoleMapper
-metadata: {name: ${RM_NAME}}
----
-apiVersion: role.keycloak.crossplane.io/v1alpha1
-kind: Role
-metadata: {name: ${TARGET_ROLE}}
-EOF
+  kubectl delete --ignore-not-found \
+    rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
+    role.role.keycloak.crossplane.io/${TARGET_ROLE} \
+    client.openidclient.keycloak.crossplane.io/${CLIENT} \
+    realm.realm.keycloak.crossplane.io/${REALM} >/dev/null 2>&1 || true
 }
 trap cleanup EXIT
 
-log "Applying Role + RoleMapper"
+log "Applying Realm + Client + Role + RoleMapper (suffix=${SUFFIX})"
 kubectl apply -f - <<EOF
+apiVersion: realm.keycloak.crossplane.io/v1alpha1
+kind: Realm
+metadata:
+  name: ${REALM}
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    realm: ${REALM}
+  providerConfigRef:
+    name: keycloak-provider-config
+---
+apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+kind: Client
+metadata:
+  name: ${CLIENT}
+spec:
+  deletionPolicy: Delete
+  forProvider:
+    realmIdRef:
+      name: ${REALM}
+    clientId: ${CLIENT}
+    accessType: PUBLIC
+  providerConfigRef:
+    name: keycloak-provider-config
+---
 apiVersion: role.keycloak.crossplane.io/v1alpha1
 kind: Role
 metadata:
@@ -94,7 +116,8 @@ metadata:
 spec:
   deletionPolicy: Delete
   forProvider:
-    realmId: ${REALM}
+    realmIdRef:
+      name: ${REALM}
     name: ${TARGET_ROLE}
   providerConfigRef:
     name: keycloak-provider-config
@@ -108,34 +131,32 @@ spec:
   providerConfigRef:
     name: keycloak-provider-config
   forProvider:
-    realmId: ${REALM}
+    realmIdRef:
+      name: ${REALM}
     clientIdRef:
-      name: ${SOURCE_CLIENT}
+      name: ${CLIENT}
     roleIdRef:
       name: ${TARGET_ROLE}
 EOF
 
-log "Waiting for Role to be Synced=True"
-kubectl wait role.role.keycloak.crossplane.io/${TARGET_ROLE} \
-  --for=condition=Synced=True --timeout=120s
-
-log "Waiting for RoleMapper to be Synced=True"
-kubectl wait rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
-  --for=condition=Synced=True --timeout=120s
+log "Waiting for all resources to be Synced=True"
+kubectl wait realm.realm.keycloak.crossplane.io/${REALM} --for=condition=Synced=True --timeout=120s
+kubectl wait client.openidclient.keycloak.crossplane.io/${CLIENT} --for=condition=Synced=True --timeout=120s
+kubectl wait role.role.keycloak.crossplane.io/${TARGET_ROLE} --for=condition=Synced=True --timeout=120s
+kubectl wait rolemapper.client.keycloak.crossplane.io/${RM_NAME} --for=condition=Synced=True --timeout=180s
 
 ORIGINAL_ROLE_ID=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
   -o jsonpath='{.spec.forProvider.roleId}')
 log "Original resolved roleId = ${ORIGINAL_ROLE_ID}"
-
 [[ -n "${ORIGINAL_ROLE_ID}" ]] || die "RoleMapper.spec.forProvider.roleId is empty after Synced"
 
 log "Deleting the Keycloak Role directly via Admin API (bypassing crossplane)"
 TOKEN=$(kc_token)
-kc_delete_role "${TOKEN}" "${TARGET_ROLE}"
+kc_delete_role "${TOKEN}"
 
-log "Recreating the Keycloak Role with the same name (will have a fresh UUID)"
-kc_create_role "${TOKEN}" "${TARGET_ROLE}"
-NEW_KC_UUID=$(kc_role_uuid "${TOKEN}" "${TARGET_ROLE}")
+log "Recreating the Keycloak Role with the same name (fresh UUID)"
+kc_create_role "${TOKEN}"
+NEW_KC_UUID=$(kc_role_uuid "${TOKEN}")
 log "New Keycloak UUID = ${NEW_KC_UUID}"
 
 [[ "${NEW_KC_UUID}" != "${ORIGINAL_ROLE_ID}" ]] \
@@ -143,22 +164,21 @@ log "New Keycloak UUID = ${NEW_KC_UUID}"
 
 log "Waiting up to 3m for the RoleMapper to recover its reference"
 deadline=$(( $(date +%s) + 180 ))
+current=""
+synced=""
 while (( $(date +%s) < deadline )); do
   current=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
     -o jsonpath='{.spec.forProvider.roleId}' 2>/dev/null || true)
   synced=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
     -o jsonpath='{.status.conditions[?(@.type=="Synced")].status}' 2>/dev/null || true)
   if [[ "${current}" == "${NEW_KC_UUID}" && "${synced}" == "True" ]]; then
-    log "PASS: roleId rewritten to new UUID and Synced=True"
-    log "  before: ${ORIGINAL_ROLE_ID}"
-    log "  after:  ${current}"
-
     anno=$(kubectl get rolemapper.client.keycloak.crossplane.io/${RM_NAME} \
       -o jsonpath='{.metadata.annotations.provider-keycloak\.crossplane\.io/stale-ref-recovery-at-generation}' \
       2>/dev/null || true)
-    if [[ -n "${anno}" ]]; then
-      log "  recovery annotation set to generation ${anno}"
-    fi
+    log "PASS: roleId rewritten and Synced=True"
+    log "  before: ${ORIGINAL_ROLE_ID}"
+    log "  after:  ${current}"
+    [[ -n "${anno}" ]] && log "  recovery annotation set to generation ${anno}"
     exit 0
   fi
   sleep 5

--- a/internal/clients/keycloak.go
+++ b/internal/clients/keycloak.go
@@ -28,6 +28,7 @@ import (
 
 	clusterv1beta1 "github.com/crossplane-contrib/provider-keycloak/apis/cluster/v1beta1"
 	namespacedv1beta1 "github.com/crossplane-contrib/provider-keycloak/apis/namespaced/v1beta1"
+	"github.com/crossplane-contrib/provider-keycloak/internal/clients/stalerefs"
 )
 
 const (
@@ -85,6 +86,12 @@ var optionalKeycloakConfigKeys = []string{
 func TerraformSetupBuilder() terraform.SetupFn {
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
 		ps := terraform.Setup{}
+
+		if recovered, err := stalerefs.MaybeRecover(ctx, client, mg); err != nil {
+			return terraform.Setup{}, errors.Wrap(err, "stale reference recovery failed")
+		} else if recovered {
+			return terraform.Setup{}, errors.New("cleared stale references; reconciling")
+		}
 
 		pcSpec, err := resolveProviderConfig(ctx, client, mg)
 		if err != nil {

--- a/internal/clients/stalerefs/stalerefs.go
+++ b/internal/clients/stalerefs/stalerefs.go
@@ -1,0 +1,198 @@
+// Package stalerefs recovers from stale cross-resource references.
+//
+// When a Keycloak resource managed by this provider references another by
+// UUID (e.g. RoleMapper.spec.forProvider.roleId resolved from roleIdRef),
+// and the referenced Keycloak object is deleted and recreated out-of-band,
+// the stored UUID becomes stale. Every subsequent reconcile fails with a
+// keycloak.ApiError{Code:404}, and the crossplane-runtime reference resolver
+// will not retry because the value field is non-empty (default resolve
+// policy: IsNoOp() returns true when the value is set).
+//
+// MaybeRecover detects this state from the Synced condition and clears every
+// reference-resolved value field on spec.forProvider (and spec.initProvider),
+// so that the next reconcile re-resolves them with the new UUIDs.
+package stalerefs
+
+import (
+	"context"
+	"reflect"
+	"strconv"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+)
+
+// RecoveryAtGenerationAnnotation records the generation at which we last
+// cleared stale references on a resource. MaybeRecover refuses to clear
+// twice within the same generation; once the user (or another controller)
+// bumps the spec, recovery becomes eligible again.
+const RecoveryAtGenerationAnnotation = "provider-keycloak.crossplane.io/stale-ref-recovery-at-generation"
+
+// Managed is the minimum subset of resource.Managed that MaybeRecover needs.
+// Narrowing the interface keeps the package independently testable.
+type Managed interface {
+	client.Object
+	GetCondition(ct xpv1.ConditionType) xpv1.Condition
+}
+
+// MaybeRecover inspects mg's Synced condition. If it signals a stale-reference
+// 404, MaybeRecover clears every value field on mg.Spec.ForProvider (and
+// mg.Spec.InitProvider) whose sibling XRef/XRefs/XSelector is non-nil, then
+// persists the update via kube. It returns true when a clearing was attempted
+// (regardless of whether the update raced with another writer).
+func MaybeRecover(ctx context.Context, kube client.Client, mg Managed) (bool, error) {
+	if !isStaleRefCondition(mg.GetCondition(xpv1.TypeSynced)) {
+		return false, nil
+	}
+	if alreadyRecoveredForCurrentGeneration(mg) {
+		return false, nil
+	}
+	if !clearResolvedRefs(mg) {
+		return false, nil
+	}
+	setRecoveryAnnotation(mg)
+	if err := kube.Update(ctx, mg); err != nil {
+		if apierrors.IsConflict(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// alreadyRecoveredForCurrentGeneration returns true when a prior reconcile
+// already cleared stale references at the current spec generation. Without
+// this guard, a referenced K8s resource that is itself stuck stale would
+// cause MaybeRecover to clear, watch the runtime resolver repopulate the
+// same stale UUID, clear again, ad infinitum.
+func alreadyRecoveredForCurrentGeneration(mg Managed) bool {
+	v, ok := mg.GetAnnotations()[RecoveryAtGenerationAnnotation]
+	if !ok {
+		return false
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return false
+	}
+	return n >= mg.GetGeneration()
+}
+
+// setRecoveryAnnotation marks the resource as recovered at its post-Update
+// generation. Clearing spec.forProvider increments the spec generation by
+// one, so we record the predicted post-Update value (mg.GetGeneration()+1)
+// to match what a subsequent reconcile will observe.
+func setRecoveryAnnotation(mg Managed) {
+	a := mg.GetAnnotations()
+	if a == nil {
+		a = map[string]string{}
+	}
+	a[RecoveryAtGenerationAnnotation] = strconv.FormatInt(mg.GetGeneration()+1, 10)
+	mg.SetAnnotations(a)
+}
+
+// isStaleRefCondition reports whether c looks like a 404 from
+// terraform-provider-keycloak. The terraform-provider-keycloak HTTP client
+// returns a *keycloak.ApiError whose Error() includes both the "ApiError"
+// type name and the "404" status code, so either substring is a reliable
+// hit when wrapped through upjet into the Synced condition message.
+func isStaleRefCondition(c xpv1.Condition) bool {
+	if c.Status != corev1.ConditionFalse {
+		return false
+	}
+	return strings.Contains(c.Message, "404") || strings.Contains(c.Message, "ApiError")
+}
+
+// clearResolvedRefs walks Spec.ForProvider and Spec.InitProvider; for each
+// suffix-paired field (X / XRef, X / XRefs, X / XSelector) whose ref or
+// selector sibling is non-nil, it zeroes the value field X. Returns true
+// if at least one value was cleared.
+func clearResolvedRefs(mg Managed) bool {
+	v := reflect.ValueOf(mg)
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+	if v.Kind() != reflect.Struct {
+		return false
+	}
+	spec := v.FieldByName("Spec")
+	if !spec.IsValid() || spec.Kind() != reflect.Struct {
+		return false
+	}
+	cleared := false
+	for _, name := range []string{"ForProvider", "InitProvider"} {
+		params := spec.FieldByName(name)
+		if !params.IsValid() {
+			continue
+		}
+		if clearRefsInStruct(params) {
+			cleared = true
+		}
+	}
+	return cleared
+}
+
+// refSuffixes are the field-name suffixes that mark a field as a reference
+// or selector sibling. Order matters: "Refs" must precede "Ref" so the
+// suffix match doesn't truncate "Refs" to "Ref" and look up the wrong value
+// field name.
+var refSuffixes = []string{"Selector", "Refs", "Ref"}
+
+func clearRefsInStruct(params reflect.Value) bool {
+	if params.Kind() != reflect.Struct {
+		return false
+	}
+	t := params.Type()
+	clearedValues := map[string]bool{}
+	cleared := false
+	for i := 0; i < params.NumField(); i++ {
+		fname := t.Field(i).Name
+		valueName, ok := valueFieldName(fname)
+		if !ok {
+			continue
+		}
+		if clearedValues[valueName] {
+			continue
+		}
+		if isNilOrEmpty(params.Field(i)) {
+			continue
+		}
+		value := params.FieldByName(valueName)
+		if !value.IsValid() || !value.CanSet() || isNilOrEmpty(value) {
+			continue
+		}
+		value.Set(reflect.Zero(value.Type()))
+		clearedValues[valueName] = true
+		cleared = true
+	}
+	return cleared
+}
+
+// valueFieldName returns the value-field name a given ref/selector field
+// resolves into, e.g. "ClientIDRef" -> "ClientID", "RoleIdsRefs" -> "RoleIds",
+// "ClientIDSelector" -> "ClientID". Returns ("", false) if the name isn't a
+// ref/selector field.
+func valueFieldName(name string) (string, bool) {
+	for _, s := range refSuffixes {
+		if strings.HasSuffix(name, s) {
+			return strings.TrimSuffix(name, s), true
+		}
+	}
+	return "", false
+}
+
+func isNilOrEmpty(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface:
+		return v.IsNil()
+	case reflect.Slice, reflect.Map:
+		return v.IsNil() || v.Len() == 0
+	case reflect.String:
+		return v.Len() == 0
+	default:
+		return false
+	}
+}

--- a/internal/clients/stalerefs/stalerefs.go
+++ b/internal/clients/stalerefs/stalerefs.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 )
 
 // RecoveryAtGenerationAnnotation records the generation at which we last
@@ -40,12 +41,16 @@ type Managed interface {
 }
 
 // MaybeRecover inspects mg's Synced condition. If it signals a stale-reference
-// 404, MaybeRecover clears every value field on mg.Spec.ForProvider (and
-// mg.Spec.InitProvider) whose sibling XRef/XRefs/XSelector is non-nil, then
-// persists the update via kube. It returns true when a clearing was attempted
-// (regardless of whether the update raced with another writer).
+// 404 AND the resource was previously created in Keycloak, MaybeRecover clears
+// every value field on mg.Spec.ForProvider (and mg.Spec.InitProvider) whose
+// sibling XRef/XRefs/XSelector is non-nil, then persists the update via kube.
+// It returns true when a clearing was attempted (regardless of whether the
+// update raced with another writer).
 func MaybeRecover(ctx context.Context, kube client.Client, mg Managed) (bool, error) {
 	if !isStaleRefCondition(mg.GetCondition(xpv1.TypeSynced)) {
+		return false, nil
+	}
+	if !wasCreatedExternally(mg) {
 		return false, nil
 	}
 	if alreadyRecoveredForCurrentGeneration(mg) {
@@ -62,6 +67,15 @@ func MaybeRecover(ctx context.Context, kube client.Client, mg Managed) (bool, er
 		return false, err
 	}
 	return true, nil
+}
+
+// wasCreatedExternally reports whether the managed resource has ever
+// successfully been created in Keycloak, as recorded by crossplane-runtime
+// via the external-create-succeeded annotation. A resource that has never
+// been created cannot hold a stale UUID; any 404 during cold start is a
+// transient parent-not-ready race and must not trigger destructive clearing.
+func wasCreatedExternally(mg Managed) bool {
+	return !meta.GetExternalCreateSucceeded(mg).IsZero()
 }
 
 // alreadyRecoveredForCurrentGeneration returns true when a prior reconcile

--- a/internal/clients/stalerefs/stalerefs.go
+++ b/internal/clients/stalerefs/stalerefs.go
@@ -185,7 +185,7 @@ func valueFieldName(name string) (string, bool) {
 }
 
 func isNilOrEmpty(v reflect.Value) bool {
-	switch v.Kind() {
+	switch v.Kind() { //nolint:exhaustive // only the kinds upjet uses for ref-paired fields matter
 	case reflect.Ptr, reflect.Interface:
 		return v.IsNil()
 	case reflect.Slice, reflect.Map:

--- a/internal/clients/stalerefs/stalerefs_test.go
+++ b/internal/clients/stalerefs/stalerefs_test.go
@@ -1,0 +1,509 @@
+package stalerefs
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
+)
+
+// fakeParams mirrors a real upjet-generated <Resource>Parameters struct: a mix
+// of singular-ref pairs, slice-ref pairs, selector-only pairs, and standalone
+// fields. The reflection walker must clear only the value fields whose sibling
+// ref/selector is set.
+type fakeParams struct {
+	// Singular ref: value + Ref + Selector
+	ClientID         *string
+	ClientIDRef      *xpv1.Reference
+	ClientIDSelector *xpv1.Selector
+
+	// Slice ref: value + Refs (plural) + Selector
+	RoleIds         []*string
+	RoleIdsRefs     []xpv1.Reference
+	RoleIdsSelector *xpv1.Selector
+
+	// Selector-only (no Ref set)
+	GroupID         *string
+	GroupIDSelector *xpv1.Selector
+
+	// Standalone (no ref siblings) — must never be cleared
+	Name *string
+
+	// Has ref name pattern but neither sibling set — must never be cleared
+	RealmID         *string
+	RealmIDRef      *xpv1.Reference
+	RealmIDSelector *xpv1.Selector
+}
+
+type fakeSpec struct {
+	ForProvider  fakeParams
+	InitProvider fakeParams
+}
+
+type fakeManaged struct {
+	metav1.TypeMeta
+	metav1.ObjectMeta
+	Spec   fakeSpec
+	Status xpv1.ConditionedStatus
+}
+
+func (f *fakeManaged) GetCondition(ct xpv1.ConditionType) xpv1.Condition {
+	return f.Status.GetCondition(ct)
+}
+
+func (f *fakeManaged) SetConditions(c ...xpv1.Condition) {
+	f.Status.SetConditions(c...)
+}
+
+func (f *fakeManaged) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+
+func (f *fakeManaged) DeepCopyObject() runtime.Object {
+	out := *f
+	out.ObjectMeta = *f.ObjectMeta.DeepCopy()
+	return &out
+}
+
+func ptr(s string) *string { return &s }
+
+func TestIsStaleRefCondition(t *testing.T) {
+	cases := []struct {
+		name string
+		cond xpv1.Condition
+		want bool
+	}{
+		{
+			name: "false status with ApiError message → stale",
+			cond: xpv1.Condition{Status: corev1.ConditionFalse, Message: "create failed: keycloak.ApiError: not found"},
+			want: true,
+		},
+		{
+			name: "false status with 404 message → stale",
+			cond: xpv1.Condition{Status: corev1.ConditionFalse, Message: "observe failed: 404 Not Found from /admin/realms"},
+			want: true,
+		},
+		{
+			name: "false status with unrelated message → not stale",
+			cond: xpv1.Condition{Status: corev1.ConditionFalse, Message: "connection refused"},
+			want: false,
+		},
+		{
+			name: "true status (synced) → not stale",
+			cond: xpv1.Condition{Status: corev1.ConditionTrue, Message: ""},
+			want: false,
+		},
+		{
+			name: "unknown status with 404 → not stale (we only fire on definite failure)",
+			cond: xpv1.Condition{Status: corev1.ConditionUnknown, Message: "404"},
+			want: false,
+		},
+		{
+			name: "empty condition → not stale",
+			cond: xpv1.Condition{},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isStaleRefCondition(tc.cond); got != tc.want {
+				t.Fatalf("isStaleRefCondition() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValueFieldName(t *testing.T) {
+	cases := []struct {
+		in        string
+		wantName  string
+		wantMatch bool
+	}{
+		{"ClientIDRef", "ClientID", true},
+		{"ClientIDSelector", "ClientID", true},
+		{"RoleIdsRefs", "RoleIds", true},
+		{"RoleIdsSelector", "RoleIds", true},
+		{"Standalone", "", false},
+		{"Selector", "", true}, // edge: "Selector" itself trims to ""
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			got, ok := valueFieldName(c.in)
+			if ok != c.wantMatch || got != c.wantName {
+				t.Fatalf("valueFieldName(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.wantName, c.wantMatch)
+			}
+		})
+	}
+}
+
+func TestClearResolvedRefs(t *testing.T) {
+	cases := []struct {
+		name        string
+		mg          *fakeManaged
+		wantCleared bool
+		check       func(t *testing.T, mg *fakeManaged)
+	}{
+		{
+			name: "singular value+ref → cleared",
+			mg: &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("stale-uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "the-client"},
+			}}},
+			wantCleared: true,
+			check: func(t *testing.T, mg *fakeManaged) {
+				if mg.Spec.ForProvider.ClientID != nil {
+					t.Errorf("ClientID not cleared: %v", *mg.Spec.ForProvider.ClientID)
+				}
+				if mg.Spec.ForProvider.ClientIDRef == nil {
+					t.Errorf("ClientIDRef was cleared but should be preserved")
+				}
+			},
+		},
+		{
+			name: "singular value+selector → cleared",
+			mg: &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+				GroupID:         ptr("stale-uuid"),
+				GroupIDSelector: &xpv1.Selector{MatchLabels: map[string]string{"app": "x"}},
+			}}},
+			wantCleared: true,
+			check: func(t *testing.T, mg *fakeManaged) {
+				if mg.Spec.ForProvider.GroupID != nil {
+					t.Errorf("GroupID not cleared: %v", *mg.Spec.ForProvider.GroupID)
+				}
+				if mg.Spec.ForProvider.GroupIDSelector == nil {
+					t.Errorf("GroupIDSelector was cleared but should be preserved")
+				}
+			},
+		},
+		{
+			name: "slice value+refs → cleared",
+			mg: &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+				RoleIds:     []*string{ptr("uuid-a"), ptr("uuid-b")},
+				RoleIdsRefs: []xpv1.Reference{{Name: "role-a"}, {Name: "role-b"}},
+			}}},
+			wantCleared: true,
+			check: func(t *testing.T, mg *fakeManaged) {
+				if len(mg.Spec.ForProvider.RoleIds) != 0 {
+					t.Errorf("RoleIds not cleared: %v", mg.Spec.ForProvider.RoleIds)
+				}
+				if len(mg.Spec.ForProvider.RoleIdsRefs) == 0 {
+					t.Errorf("RoleIdsRefs was cleared but should be preserved")
+				}
+			},
+		},
+		{
+			name: "value present but no ref/selector → untouched (manual UUID)",
+			mg: &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+				RealmID: ptr("manually-set-uuid"),
+			}}},
+			wantCleared: false,
+			check: func(t *testing.T, mg *fakeManaged) {
+				if mg.Spec.ForProvider.RealmID == nil || *mg.Spec.ForProvider.RealmID != "manually-set-uuid" {
+					t.Errorf("RealmID was incorrectly cleared")
+				}
+			},
+		},
+		{
+			name: "standalone field → untouched",
+			mg: &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+				Name: ptr("my-rolemapper"),
+			}}},
+			wantCleared: false,
+		},
+		{
+			name: "value already empty → no clearing needed",
+			mg: &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+				ClientIDRef: &xpv1.Reference{Name: "x"},
+			}}},
+			wantCleared: false,
+		},
+		{
+			name: "InitProvider also cleared",
+			mg: &fakeManaged{Spec: fakeSpec{
+				ForProvider: fakeParams{
+					ClientID:    ptr("stale-1"),
+					ClientIDRef: &xpv1.Reference{Name: "c"},
+				},
+				InitProvider: fakeParams{
+					ClientID:    ptr("stale-2"),
+					ClientIDRef: &xpv1.Reference{Name: "c"},
+				},
+			}},
+			wantCleared: true,
+			check: func(t *testing.T, mg *fakeManaged) {
+				if mg.Spec.ForProvider.ClientID != nil {
+					t.Errorf("ForProvider.ClientID not cleared")
+				}
+				if mg.Spec.InitProvider.ClientID != nil {
+					t.Errorf("InitProvider.ClientID not cleared")
+				}
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := clearResolvedRefs(tc.mg)
+			if got != tc.wantCleared {
+				t.Fatalf("clearResolvedRefs() = %v, want %v", got, tc.wantCleared)
+			}
+			if tc.check != nil {
+				tc.check(t, tc.mg)
+			}
+		})
+	}
+}
+
+func TestMaybeRecover(t *testing.T) {
+	staleCond := xpv1.Condition{
+		Type:    xpv1.TypeSynced,
+		Status:  corev1.ConditionFalse,
+		Reason:  xpv1.ReasonReconcileError,
+		Message: "observe failed: keycloak.ApiError: 404 not found",
+	}
+	healthyCond := xpv1.Condition{
+		Type:   xpv1.TypeSynced,
+		Status: corev1.ConditionTrue,
+		Reason: xpv1.ReasonReconcileSuccess,
+	}
+
+	t.Run("healthy: no-op", func(t *testing.T) {
+		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+			ClientID:    ptr("uuid"),
+			ClientIDRef: &xpv1.Reference{Name: "c"},
+		}}}
+		mg.SetConditions(healthyCond)
+
+		updateCalled := false
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				updateCalled = true
+				return nil
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (false,nil)", recovered, err)
+		}
+		if updateCalled {
+			t.Errorf("kube.Update was called on a healthy resource")
+		}
+		if mg.Spec.ForProvider.ClientID == nil {
+			t.Errorf("ClientID cleared on a healthy resource")
+		}
+	})
+
+	t.Run("stale: clears and persists", func(t *testing.T) {
+		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+			ClientID:    ptr("uuid"),
+			ClientIDRef: &xpv1.Reference{Name: "c"},
+		}}}
+		mg.SetConditions(staleCond)
+
+		var persisted *fakeManaged
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				persisted = obj.(*fakeManaged)
+				return nil
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || !recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (true,nil)", recovered, err)
+		}
+		if persisted == nil {
+			t.Fatalf("kube.Update was not called")
+		}
+		if persisted.Spec.ForProvider.ClientID != nil {
+			t.Errorf("persisted ClientID was not cleared: %v", *persisted.Spec.ForProvider.ClientID)
+		}
+	})
+
+	t.Run("stale but nothing to clear → no-op", func(t *testing.T) {
+		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+			Name: ptr("no-refs-here"),
+		}}}
+		mg.SetConditions(staleCond)
+
+		updateCalled := false
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				updateCalled = true
+				return nil
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (false,nil)", recovered, err)
+		}
+		if updateCalled {
+			t.Errorf("kube.Update was called when nothing was cleared")
+		}
+	})
+
+	t.Run("update conflict → treated as benign", func(t *testing.T) {
+		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+			ClientID:    ptr("uuid"),
+			ClientIDRef: &xpv1.Reference{Name: "c"},
+		}}}
+		mg.SetConditions(staleCond)
+
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				return apierrors.NewConflict(schema.GroupResource{Group: "x", Resource: "y"}, "name", errors.New("stale"))
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil {
+			t.Fatalf("MaybeRecover() returned unexpected error: %v", err)
+		}
+		if !recovered {
+			t.Fatalf("expected recovered=true even on conflict, got false")
+		}
+	})
+
+	t.Run("annotation matches current generation → skip", func(t *testing.T) {
+		mg := &fakeManaged{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation:  5,
+				Annotations: map[string]string{RecoveryAtGenerationAnnotation: "5"},
+			},
+			Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "c"},
+			}},
+		}
+		mg.SetConditions(staleCond)
+
+		updateCalled := false
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				updateCalled = true
+				return nil
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (false,nil) — already recovered this gen", recovered, err)
+		}
+		if updateCalled {
+			t.Errorf("kube.Update was called despite annotation guard")
+		}
+		if mg.Spec.ForProvider.ClientID == nil {
+			t.Errorf("ClientID was cleared despite annotation guard")
+		}
+	})
+
+	t.Run("annotation older than current generation → recover again", func(t *testing.T) {
+		mg := &fakeManaged{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation:  7,
+				Annotations: map[string]string{RecoveryAtGenerationAnnotation: "5"},
+			},
+			Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "c"},
+			}},
+		}
+		mg.SetConditions(staleCond)
+
+		var persistedAnno string
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				persistedAnno = obj.GetAnnotations()[RecoveryAtGenerationAnnotation]
+				return nil
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || !recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (true,nil)", recovered, err)
+		}
+		if persistedAnno != "8" {
+			t.Errorf("annotation = %q, want %q (current gen + 1)", persistedAnno, "8")
+		}
+	})
+
+	t.Run("annotation malformed → recover (defensive)", func(t *testing.T) {
+		mg := &fakeManaged{
+			ObjectMeta: metav1.ObjectMeta{
+				Generation:  1,
+				Annotations: map[string]string{RecoveryAtGenerationAnnotation: "not-a-number"},
+			},
+			Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "c"},
+			}},
+		}
+		mg.SetConditions(staleCond)
+
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error { return nil },
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || !recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (true,nil) — malformed annotation should not block recovery", recovered, err)
+		}
+	})
+
+	t.Run("first recovery sets annotation to gen+1", func(t *testing.T) {
+		const gen int64 = 3
+		mg := &fakeManaged{
+			ObjectMeta: metav1.ObjectMeta{Generation: gen},
+			Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "c"},
+			}},
+		}
+		mg.SetConditions(staleCond)
+
+		var persisted *fakeManaged
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+				persisted = obj.(*fakeManaged)
+				return nil
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || !recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (true,nil)", recovered, err)
+		}
+		got := persisted.GetAnnotations()[RecoveryAtGenerationAnnotation]
+		want := strconv.FormatInt(gen+1, 10)
+		if got != want {
+			t.Errorf("annotation = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("update non-conflict error → returned", func(t *testing.T) {
+		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
+			ClientID:    ptr("uuid"),
+			ClientIDRef: &xpv1.Reference{Name: "c"},
+		}}}
+		mg.SetConditions(staleCond)
+
+		wantErr := errors.New("nope")
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				return wantErr
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("MaybeRecover() err = %v, want %v", err, wantErr)
+		}
+		if recovered {
+			t.Errorf("expected recovered=false on non-conflict error")
+		}
+	})
+}
+
+// Compile-time check: ensure fakeManaged satisfies the narrow Managed
+// interface used by MaybeRecover.
+var _ Managed = (*fakeManaged)(nil)

--- a/internal/clients/stalerefs/stalerefs_test.go
+++ b/internal/clients/stalerefs/stalerefs_test.go
@@ -69,7 +69,7 @@ func (f *fakeManaged) GetObjectKind() schema.ObjectKind { return schema.EmptyObj
 
 func (f *fakeManaged) DeepCopyObject() runtime.Object {
 	out := *f
-	out.ObjectMeta = *f.ObjectMeta.DeepCopy()
+	out.ObjectMeta = *f.DeepCopy()
 	return &out
 }
 

--- a/internal/clients/stalerefs/stalerefs_test.go
+++ b/internal/clients/stalerefs/stalerefs_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strconv"
 	"testing"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,8 +15,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/meta"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 )
+
+// createdExternally returns a metav1.ObjectMeta marked with the annotation
+// crossplane-runtime sets after the first successful external Create. Tests
+// that exercise stale-reference recovery must use this — without it the
+// MaybeRecover gate (correctly) classifies the resource as never-created and
+// skips clearing.
+func createdExternally() metav1.ObjectMeta {
+	return metav1.ObjectMeta{
+		Annotations: map[string]string{
+			meta.AnnotationKeyExternalCreateSucceeded: time.Now().Format(time.RFC3339),
+		},
+	}
+}
 
 // fakeParams mirrors a real upjet-generated <Resource>Parameters struct: a mix
 // of singular-ref pairs, slice-ref pairs, selector-only pairs, and standalone
@@ -301,10 +316,13 @@ func TestMaybeRecover(t *testing.T) {
 	})
 
 	t.Run("stale: clears and persists", func(t *testing.T) {
-		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
-			ClientID:    ptr("uuid"),
-			ClientIDRef: &xpv1.Reference{Name: "c"},
-		}}}
+		mg := &fakeManaged{
+			ObjectMeta: createdExternally(),
+			Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "c"},
+			}},
+		}
 		mg.SetConditions(staleCond)
 
 		var persisted *fakeManaged
@@ -327,9 +345,12 @@ func TestMaybeRecover(t *testing.T) {
 	})
 
 	t.Run("stale but nothing to clear → no-op", func(t *testing.T) {
-		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
-			Name: ptr("no-refs-here"),
-		}}}
+		mg := &fakeManaged{
+			ObjectMeta: createdExternally(),
+			Spec: fakeSpec{ForProvider: fakeParams{
+				Name: ptr("no-refs-here"),
+			}},
+		}
 		mg.SetConditions(staleCond)
 
 		updateCalled := false
@@ -349,10 +370,13 @@ func TestMaybeRecover(t *testing.T) {
 	})
 
 	t.Run("update conflict → treated as benign", func(t *testing.T) {
-		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
-			ClientID:    ptr("uuid"),
-			ClientIDRef: &xpv1.Reference{Name: "c"},
-		}}}
+		mg := &fakeManaged{
+			ObjectMeta: createdExternally(),
+			Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "c"},
+			}},
+		}
 		mg.SetConditions(staleCond)
 
 		kube := &test.MockClient{
@@ -372,8 +396,11 @@ func TestMaybeRecover(t *testing.T) {
 	t.Run("annotation matches current generation → skip", func(t *testing.T) {
 		mg := &fakeManaged{
 			ObjectMeta: metav1.ObjectMeta{
-				Generation:  5,
-				Annotations: map[string]string{RecoveryAtGenerationAnnotation: "5"},
+				Generation: 5,
+				Annotations: map[string]string{
+					RecoveryAtGenerationAnnotation:            "5",
+					meta.AnnotationKeyExternalCreateSucceeded: time.Now().Format(time.RFC3339),
+				},
 			},
 			Spec: fakeSpec{ForProvider: fakeParams{
 				ClientID:    ptr("uuid"),
@@ -404,8 +431,11 @@ func TestMaybeRecover(t *testing.T) {
 	t.Run("annotation older than current generation → recover again", func(t *testing.T) {
 		mg := &fakeManaged{
 			ObjectMeta: metav1.ObjectMeta{
-				Generation:  7,
-				Annotations: map[string]string{RecoveryAtGenerationAnnotation: "5"},
+				Generation: 7,
+				Annotations: map[string]string{
+					RecoveryAtGenerationAnnotation:            "5",
+					meta.AnnotationKeyExternalCreateSucceeded: time.Now().Format(time.RFC3339),
+				},
 			},
 			Spec: fakeSpec{ForProvider: fakeParams{
 				ClientID:    ptr("uuid"),
@@ -433,8 +463,11 @@ func TestMaybeRecover(t *testing.T) {
 	t.Run("annotation malformed → recover (defensive)", func(t *testing.T) {
 		mg := &fakeManaged{
 			ObjectMeta: metav1.ObjectMeta{
-				Generation:  1,
-				Annotations: map[string]string{RecoveryAtGenerationAnnotation: "not-a-number"},
+				Generation: 1,
+				Annotations: map[string]string{
+					RecoveryAtGenerationAnnotation:            "not-a-number",
+					meta.AnnotationKeyExternalCreateSucceeded: time.Now().Format(time.RFC3339),
+				},
 			},
 			Spec: fakeSpec{ForProvider: fakeParams{
 				ClientID:    ptr("uuid"),
@@ -455,7 +488,12 @@ func TestMaybeRecover(t *testing.T) {
 	t.Run("first recovery sets annotation to gen+1", func(t *testing.T) {
 		const gen int64 = 3
 		mg := &fakeManaged{
-			ObjectMeta: metav1.ObjectMeta{Generation: gen},
+			ObjectMeta: metav1.ObjectMeta{
+				Generation: gen,
+				Annotations: map[string]string{
+					meta.AnnotationKeyExternalCreateSucceeded: time.Now().Format(time.RFC3339),
+				},
+			},
 			Spec: fakeSpec{ForProvider: fakeParams{
 				ClientID:    ptr("uuid"),
 				ClientIDRef: &xpv1.Reference{Name: "c"},
@@ -481,11 +519,49 @@ func TestMaybeRecover(t *testing.T) {
 		}
 	})
 
-	t.Run("update non-conflict error → returned", func(t *testing.T) {
+	// Regression: a never-created resource that takes a 404 during cold start
+	// (e.g. parent realm not yet in Keycloak) must NOT have its sibling-XRef
+	// value fields cleared. Clearing them strands fields like serviceAccountUserId
+	// — whose resolver pulls from a sibling resource's status — empty, and the
+	// per-generation guard then locks recovery off, leaving the resource stuck
+	// for the full reconcile budget.
+	t.Run("never created externally → skip even with stale-looking condition", func(t *testing.T) {
 		mg := &fakeManaged{Spec: fakeSpec{ForProvider: fakeParams{
 			ClientID:    ptr("uuid"),
 			ClientIDRef: &xpv1.Reference{Name: "c"},
 		}}}
+		mg.SetConditions(staleCond)
+
+		updateCalled := false
+		kube := &test.MockClient{
+			MockUpdate: func(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+				updateCalled = true
+				return nil
+			},
+		}
+		recovered, err := MaybeRecover(context.Background(), kube, mg)
+		if err != nil || recovered {
+			t.Fatalf("MaybeRecover() = (%v,%v), want (false,nil) — cold-start 404 must not trigger clearing", recovered, err)
+		}
+		if updateCalled {
+			t.Errorf("kube.Update was called on a never-created resource")
+		}
+		if mg.Spec.ForProvider.ClientID == nil {
+			t.Errorf("ClientID cleared on a never-created resource")
+		}
+		if _, ok := mg.GetAnnotations()[RecoveryAtGenerationAnnotation]; ok {
+			t.Errorf("recovery annotation was set despite cold-start gate")
+		}
+	})
+
+	t.Run("update non-conflict error → returned", func(t *testing.T) {
+		mg := &fakeManaged{
+			ObjectMeta: createdExternally(),
+			Spec: fakeSpec{ForProvider: fakeParams{
+				ClientID:    ptr("uuid"),
+				ClientIDRef: &xpv1.Reference{Name: "c"},
+			}},
+		}
 		mg.SetConditions(staleCond)
 
 		wantErr := errors.New("nope")


### PR DESCRIPTION
## Summary

- When a Keycloak object referenced by a managed resource (e.g. `RoleMapper.spec.forProvider.roleId` resolved from `roleIdRef`) is deleted and recreated out-of-band, the stored UUID becomes stale. The crossplane-runtime reference resolver does not retry — its `IsNoOp()` returns `true` while the value field is non-empty — so the resource stays stuck with `Synced=False` and a `keycloak.ApiError{Code:404}` forever. Today the only workaround is `resolve: Always` on every ref.
- This change adds `internal/clients/stalerefs`. On each reconcile it inspects the `Synced` condition; on a `404`/`ApiError` signature it clears every value field on `spec.forProvider` and `spec.initProvider` whose sibling `XRef` / `XRefs` / `XSelector` is set, then persists the spec. The runtime resolver repopulates with current UUIDs on the next reconcile.
- Wired into `TerraformSetupBuilder` (`internal/clients/keycloak.go`) so it applies to every cluster- and namespaced-scoped managed resource without forking any generated controller.
- A per-generation annotation (`provider-keycloak.crossplane.io/stale-ref-recovery-at-generation`) prevents oscillation if the referenced resource is itself stuck stale: recovery runs at most once per spec generation, becoming eligible again only when generation advances.

### Detection heuristic

The Synced condition message must contain `"404"` or `"ApiError"`. Both substrings are present today in errors surfaced from `terraform-provider-keycloak`'s `*keycloak.ApiError` (same pattern used in `config/role/config.go` and `config/lookup/identifying_properties_lookup.go`). If upjet wrapping changes the surface form, this heuristic will silently stop firing — covered by unit tests so drift surfaces immediately.

### Out of scope

- Surgical clearing (only the specific stale UUID): chose all-fields clearing — healthy refs re-resolve cheaply via K8s GETs, no Keycloak calls.
- Annotation-based opt-in: behaviour is on by default.
- Detection signals beyond the `Synced` condition (e.g. callback errors): can be layered on later if message-string detection proves noisy.

## Test plan

- [x] Unit tests added: `go test ./internal/clients/stalerefs/...` — 32 tests covering the 404 heuristic, value/ref/selector pairing (singular and slice), `ForProvider` and `InitProvider` walking, untouched standalone/manual fields, the annotation guard (first recovery stamps, same-gen skips, older-gen re-triggers, malformed defensives), conflict handling and error propagation.
- [x] Full suite: `go test ./...` (45 + 4 new = 49 tests, 192 packages)
- [x] `go build ./...` and `go vet ./...` clean
- [ ] **Manual e2e** (`dev/test/stale-ref-recovery.sh` included): apply a Role + RoleMapper, delete the Role directly via Keycloak Admin API, recreate it (new UUID), confirm the RoleMapper transitions back to `Synced=True` with the new UUID resolved into `spec.forProvider.roleId` and the recovery annotation set.