### PR TITLE
feat(writeConnectionSecretToRef): publish client credentials as connection details

### DIFF
--- a/config/openidclient/config.go
+++ b/config/openidclient/config.go
@@ -17,6 +17,25 @@ const (
 	Group = "openidclient"
 )
 
+// clientConnectionDetails publishes an OpenID client's credentials as connection
+// details under simplified, camelCase keys so consumers (e.g. Argo CD) can mount them
+// directly from the connection secret. client_secret is a computed attribute for
+// CONFIDENTIAL clients, so it is present in the Terraform state. Upjet already
+// publishes the raw attribute.<name> variants; empty values are omitted here.
+func clientConnectionDetails(attr map[string]any) (map[string][]byte, error) {
+	conn := map[string][]byte{}
+	if v, ok := attr["client_secret"].(string); ok && v != "" {
+		conn["clientSecret"] = []byte(v)
+	}
+	if v, ok := attr["client_id"].(string); ok && v != "" {
+		conn["clientID"] = []byte(v)
+	}
+	if v, ok := attr["service_account_user_id"].(string); ok && v != "" {
+		conn["serviceAccountUserId"] = []byte(v)
+	}
+	return conn, nil
+}
+
 // Configure configures individual resources by adding custom ResourceConfigurators.
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("keycloak_openid_client", func(r *config.Resource) {
@@ -41,6 +60,9 @@ func Configure(p *config.Provider) {
 				"authentication_flow_binding_overrides.direct_grant_id",
 			},
 		}
+
+		// Publish the client's credentials as connection details.
+		r.Sensitive.AdditionalConnectionDetailsFn = clientConnectionDetails
 	})
 
 	p.AddResourceConfigurator("keycloak_openid_client_default_scopes", func(r *config.Resource) {

--- a/config/openidclient/config_test.go
+++ b/config/openidclient/config_test.go
@@ -1,0 +1,33 @@
+package openidclient
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestClientConnectionDetails locks the published keys to the simplified aliases
+// only: it must not re-emit the raw attribute.<name> keys (Upjet adds those, and
+// duplicating them conflicts), and empty values must be omitted.
+func TestClientConnectionDetails(t *testing.T) {
+	got, err := clientConnectionDetails(map[string]any{
+		"client_secret":           "s3cret",
+		"client_id":               "my-client",
+		"service_account_user_id": "sa-123",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := map[string][]byte{
+		"clientSecret":         []byte("s3cret"),
+		"clientID":             []byte("my-client"),
+		"serviceAccountUserId": []byte("sa-123"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("clientConnectionDetails() = %v, want %v", got, want)
+	}
+
+	// Absent or empty values are omitted, not published as empty keys.
+	if got, _ := clientConnectionDetails(map[string]any{"client_secret": ""}); len(got) != 0 {
+		t.Errorf("expected no keys for empty/absent values, got %v", got)
+	}
+}

--- a/examples/openidclient/client-with-connection-details.yaml
+++ b/examples/openidclient/client-with-connection-details.yaml
@@ -1,0 +1,36 @@
+apiVersion: realm.keycloak.crossplane.io/v1alpha1
+kind: Realm
+metadata:
+  name: example-connection-details-realm
+spec:
+  forProvider:
+    realm: example-connection-details
+    enabled: true
+  providerConfigRef:
+    name: keycloak-provider-config
+---
+apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+kind: Client
+metadata:
+  name: example-connection-details-client
+spec:
+  forProvider:
+    clientId: example-connection-details-client
+    enabled: true
+    accessType: CONFIDENTIAL
+    standardFlowEnabled: true
+    serviceAccountsEnabled: true
+    realmIdRef:
+      name: example-connection-details-realm
+    validRedirectUris:
+      - "https://app.cluster.local/auth/callback"
+  # For a CONFIDENTIAL client, the connection secret is populated with the
+  # client's credentials under simplified keys:
+  #   - clientSecret
+  #   - clientID
+  #   - serviceAccountUserId  (when serviceAccountsEnabled is true)
+  writeConnectionSecretToRef:
+    name: example-connection-details-secret
+    namespace: crossplane-system
+  providerConfigRef:
+    name: keycloak-provider-config


### PR DESCRIPTION
### Description of your changes
Add an AdditionalConnectionDetailsFn to keycloak_openid_client that writes the client's credentials into its connection secret under simplified keys: clientSecret, clientID and serviceAccountUserId.

This lets consumers mount the credentials directly from the connection secret (e.g. wiring an OIDC client secret into Argo CD or another app) without an extra copy step. Empty values are omitted, and the raw attribute.<name> keys Upjet publishes itself are left untouched.

Fixes #596

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This code has been running as a fork for about a month.

[contribution process]: https://git.io/fj2m9
