### PR TITLE
fix: make Keycloak client concurrency-safe with a per-config client pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,15 @@ schema-diff: $(TERRAFORM)
 	./scripts/version_diff.py config/generated.lst $(WORK_DIR)/schema-diff/old-schema.json config/schema.json || true
 	@$(OK) Comparing provider schema $(OLD_PROVIDER_VERSION) vs $(TERRAFORM_PROVIDER_VERSION)
 
-.PHONY: cobertura submodules fallthrough run crds.clean schema-diff schema-version-diff
+# test.race runs the concurrency-safety unit tests with the Go race detector.
+# It is separate from `make test` because the full suite starts kube-apiservers
+# that do not need the race detector.
+test.race:
+	@$(INFO) running race detector tests
+	@CGO_ENABLED=1 go test -race -count=1 ./internal/tfconcurrency/... ./internal/clients/... ./config/...
+	@$(OK) running race detector tests
+
+.PHONY: cobertura submodules fallthrough run crds.clean schema-diff schema-version-diff test.race
 
 # ====================================================================================
 # Special Targets
@@ -369,6 +377,7 @@ Crossplane Targets:
     run                   Run crossplane locally, out-of-cluster. Useful for development.
     schema-diff           Compare provider schema between versions. Usage: make schema-diff OLD_PROVIDER_VERSION=5.6.0
     schema-version-diff   Check for schema version changes against the base branch (CI).
+    test.race             Run the concurrency-safety unit tests with the Go race detector.
 
 endef
 # The reason CROSSPLANE_MAKE_HELP is used instead of CROSSPLANE_HELP is because the crossplane

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ The provider supports the following command-line flags, which can be set via `De
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--max-reconcile-rate` | `10` | The global maximum rate per second at which resources may be checked for drift from the desired state. |
-| `--max-concurrent-reconciles` | `1` | The maximum number of concurrent reconcile operations per controller. |
+| `--max-concurrent-reconciles` | `5` | The maximum number of concurrent reconcile operations per controller. |
+| `--keycloak-client-pool-size` | `5` | The maximum number of Keycloak client connections created per provider configuration to serve concurrent operations safely. |
 | `--poll` | `10m` | Poll interval controls how often an individual resource should be checked for drift. |
 | `--sync` | `1h` | Controller manager sync period. |
 | `--leader-election` | `false` | Use leader election for the controller manager. |
@@ -65,9 +66,14 @@ The provider supports the following command-line flags, which can be set via `De
 
 ##### Concurrency tuning
 
-By default, `--max-concurrent-reconciles` is set to `1` to prevent `concurrent map writes` panics that can occur when multiple goroutines reconcile resources of the same type concurrently (see [#552](https://github.com/crossplane-contrib/provider-keycloak/issues/552)).
+The provider serves concurrent reconciliations safely by giving each in-flight operation its own Keycloak client, borrowed from a small per-configuration pool. The embedded `terraform-provider-keycloak` client is not safe for concurrent use, so a single shared client previously caused `concurrent map writes` panics under load (see [#552](https://github.com/crossplane-contrib/provider-keycloak/issues/552)); the pool removes that race while preserving concurrency.
 
-If you need higher throughput and are not experiencing crashes, you can increase concurrency:
+Two independent knobs control throughput:
+
+- `--max-concurrent-reconciles` (default `5`) sets how many reconcile operations each controller may run at once.
+- `--keycloak-client-pool-size` (default `5`) bounds how many Keycloak connections are opened per provider configuration. This is the effective ceiling on concurrent calls against a single Keycloak instance; raising `--max-concurrent-reconciles` above it only increases queueing, not Keycloak throughput.
+
+To increase throughput, raise both together:
 
 ```yaml
 ---
@@ -85,7 +91,8 @@ spec:
             - name: package-runtime
               args:
                 - --max-reconcile-rate=10
-                - --max-concurrent-reconciles=5
+                - --max-concurrent-reconciles=10
+                - --keycloak-client-pool-size=10
 ```
 
 which can be used in the provider resource as follows:

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -71,7 +71,8 @@ func main() {
 		pollStateMetricInterval = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
 		leaderElection          = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
-		maxConcurrentReconciles = app.Flag("max-concurrent-reconciles", "The maximum number of concurrent reconcile operations per controller. Set to 1 to avoid concurrent map write panics.").Default("1").Int()
+		maxConcurrentReconciles = app.Flag("max-concurrent-reconciles", "The maximum number of concurrent reconcile operations per controller.").Default("5").Int()
+		keycloakClientPoolSize  = app.Flag("keycloak-client-pool-size", "The maximum number of Keycloak client connections created per provider configuration to serve concurrent operations safely.").Default("5").Int()
 		webhookPort             = app.Flag("webhook-port", "The port the webhook listens on").Default("9443").Envar("WEBHOOK_PORT").Int()
 		metricsBindAddress      = app.Flag("metrics-bind-address", "The address the metrics server listens on").Default(":8080").Envar("METRICS_BIND_ADDRESS").String()
 
@@ -192,7 +193,7 @@ func main() {
 			},
 		},
 		Provider:              providerCluster,
-		SetupFn:               clients.TerraformSetupBuilder(),
+		SetupFn:               clients.TerraformSetupBuilder(*keycloakClientPoolSize),
 		PollJitter:            pollJitter,
 		OperationTrackerStore: tjcontroller.NewOperationStore(log),
 	}
@@ -210,7 +211,7 @@ func main() {
 			},
 		},
 		Provider:              providerNamespaced,
-		SetupFn:               clients.TerraformSetupBuilder(),
+		SetupFn:               clients.TerraformSetupBuilder(*keycloakClientPoolSize),
 		PollJitter:            pollJitter,
 		OperationTrackerStore: tjcontroller.NewOperationStore(log),
 	}

--- a/config/lookup/identifying_properties_lookup.go
+++ b/config/lookup/identifying_properties_lookup.go
@@ -47,6 +47,9 @@ func GetIDFromIdentifyingProperties(ctx context.Context, externalName string, pa
 		return "", err
 	}
 
+	unlock := lockForLookupConfig(terraformProviderConfig)
+	defer unlock()
+
 	processedParameters := make(map[string]any)
 
 	for _, reqParamName := range lookupConfig.RequiredParameters {

--- a/config/lookup/keycloak_client.go
+++ b/config/lookup/keycloak_client.go
@@ -39,6 +39,21 @@ var (
 	keycloakClientCacheMu sync.Mutex
 )
 
+// lookupClientMu holds a per-configuration mutex that serializes access to the
+// shared lookup client, which is not safe for concurrent use.
+var lookupClientMu sync.Map // map[string]*sync.Mutex
+
+// lockForLookupConfig locks the per-configuration lookup mutex and returns its
+// unlock function.
+func lockForLookupConfig(terraformProviderConfig map[string]any) func() {
+	c := terraformProviderConfig["configuration"].(terraform.ProviderConfiguration)
+	key := keycloaksession.ConfigCacheKey(c)
+	v, _ := lookupClientMu.LoadOrStore(key, &sync.Mutex{})
+	m := v.(*sync.Mutex)
+	m.Lock()
+	return m.Unlock
+}
+
 // newKeycloakClient creates a new keycloak client based on the settings in the provider configuration
 // (This can be removed once this issue is resolved: https://github.com/crossplane/upjet/issues/464)
 func newKeycloakClient(ctx context.Context, terraformProviderConfig map[string]any) (*keycloak.KeycloakClient, error) {

--- a/config/provider.go
+++ b/config/provider.go
@@ -29,6 +29,7 @@ import (
 	"github.com/crossplane-contrib/provider-keycloak/config/samlclient"
 	"github.com/crossplane-contrib/provider-keycloak/config/user"
 	"github.com/crossplane-contrib/provider-keycloak/config/workflow"
+	"github.com/crossplane-contrib/provider-keycloak/internal/tfconcurrency"
 
 	// Note(turkenh): we are importing this to embed provider schema document
 	_ "embed"
@@ -81,6 +82,11 @@ func GetProvider(generationProvider bool) (*ujconfig.Provider, error) {
 		return nil, errors.Wrapf(err, "cannot get the Terraform provider schema with generation mode set to %t", generationProvider)
 	}
 
+	// Make the shared Terraform SDK resources safe for concurrent use: each
+	// callback borrows a dedicated pooled client instead of racing on the single
+	// shared one (see internal/tfconcurrency).
+	tfconcurrency.WrapProvider(p)
+
 	pc := ujconfig.NewProvider([]byte(providerSchema), resourcePrefix, modulePath, []byte(providerMetadata),
 		ujconfig.WithIncludeList([]string{}),
 		ujconfig.WithTerraformPluginSDKIncludeList(ExternalNameConfigured()),
@@ -131,6 +137,8 @@ func GetProviderNamespaced(generationProvider bool) (*ujconfig.Provider, error) 
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot get the Terraform provider schema with generation mode set to %t", generationProvider)
 	}
+
+	tfconcurrency.WrapProvider(p)
 
 	pc := ujconfig.NewProvider([]byte(providerSchema), resourcePrefix, modulePath, []byte(providerMetadata),
 		ujconfig.WithShortName("keycloak"),

--- a/internal/clients/keycloak.go
+++ b/internal/clients/keycloak.go
@@ -32,6 +32,7 @@ import (
 	namespacedv1beta1 "github.com/crossplane-contrib/provider-keycloak/apis/namespaced/v1beta1"
 	"github.com/crossplane-contrib/provider-keycloak/internal/clients/stalerefs"
 	"github.com/crossplane-contrib/provider-keycloak/internal/keycloaksession"
+	"github.com/crossplane-contrib/provider-keycloak/internal/tfconcurrency"
 )
 
 const (
@@ -56,6 +57,7 @@ const (
 type cachedMeta struct {
 	meta   interface{}
 	config map[string]any
+	pool   *tfconcurrency.Pool
 }
 
 // metaCache caches the configured Terraform provider meta (keycloak
@@ -103,7 +105,7 @@ var optionalKeycloakConfigKeys = []string{
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
 // returns Terraform provider setup configuration
 // nolint: gocyclo
-func TerraformSetupBuilder() terraform.SetupFn {
+func TerraformSetupBuilder(poolSize int) terraform.SetupFn {
 	return func(ctx context.Context, client client.Client, mg resource.Managed) (terraform.Setup, error) {
 		ps := terraform.Setup{}
 
@@ -168,11 +170,27 @@ func TerraformSetupBuilder() terraform.SetupFn {
 			return ps, errors.Wrap(err, "failed to configure the no-fork client")
 		}
 
+		primary, ok := ps.Meta.(*keycloak.KeycloakClient)
+		if !ok {
+			return ps, errors.New("configured provider meta is not a *keycloak.KeycloakClient")
+		}
+		// Build a bounded pool of sibling clients for this configuration so that
+		// concurrent reconciliations each borrow their own client instead of
+		// racing on the single shared one. The primary client is seeded into the
+		// pool so it is reused rather than left idle.
+		cfg := ps.Configuration
+		pool := tfconcurrency.NewPool(poolSize, func(fctx context.Context) (*keycloak.KeycloakClient, error) {
+			return newConfiguredKeycloakClient(fctx, cfg)
+		})
+		pool.Seed(primary)
+		tfconcurrency.Register(primary, pool)
+
 		// Store only the fields needed for logout to reduce sensitive
 		// credential exposure in process memory.
 		metaCache.Store(cacheKey, &cachedMeta{
 			meta:   ps.Meta,
 			config: keycloaksession.LogoutConfig(ps.Configuration),
+			pool:   pool,
 		})
 		return ps, nil
 	}
@@ -308,16 +326,28 @@ func ExtractCredentials(ctx context.Context, source xpv1.CredentialsSource, clie
 
 // Function to setup provider that uses terraform SDK
 func configureNoForkKeycloakClient(ctx context.Context, ps *terraform.Setup) error {
-
-	cb := keycloakProvider.KeycloakProvider(nil)
-
-	diags := cb.Configure(ctx, terraformSDK.NewResourceConfigRaw(ps.Configuration))
-	if diags.HasError() {
-		return fmt.Errorf("failed to configure the Keycloak provider: %v", diags)
+	client, err := newConfiguredKeycloakClient(ctx, ps.Configuration)
+	if err != nil {
+		return err
 	}
-
-	ps.Meta = cb.Meta()
+	ps.Meta = client
 	return nil
+}
+
+// newConfiguredKeycloakClient builds and configures a *keycloak.KeycloakClient
+// from a provider configuration (performing the initial login). It is used both
+// for the primary client and for the additional clients in the per-config pool.
+func newConfiguredKeycloakClient(ctx context.Context, config map[string]any) (*keycloak.KeycloakClient, error) {
+	cb := keycloakProvider.KeycloakProvider(nil)
+	diags := cb.Configure(ctx, terraformSDK.NewResourceConfigRaw(config))
+	if diags.HasError() {
+		return nil, fmt.Errorf("failed to configure the Keycloak provider: %v", diags)
+	}
+	client, ok := cb.Meta().(*keycloak.KeycloakClient)
+	if !ok {
+		return nil, fmt.Errorf("configured provider meta is not a *keycloak.KeycloakClient")
+	}
+	return client, nil
 }
 
 // CleanupSessions logs out all cached Keycloak sessions. It should be
@@ -326,7 +356,14 @@ func configureNoForkKeycloakClient(ctx context.Context, ps *terraform.Setup) err
 func CleanupSessions(ctx context.Context) {
 	metaCache.Range(func(key, value any) bool {
 		entry := value.(*cachedMeta)
-		if kcClient, ok := entry.meta.(*keycloak.KeycloakClient); ok {
+		if entry.pool != nil {
+			for _, c := range entry.pool.Clients() {
+				keycloaksession.LogoutSession(ctx, entry.config, c)
+			}
+			if primary, ok := entry.meta.(*keycloak.KeycloakClient); ok {
+				tfconcurrency.Unregister(primary)
+			}
+		} else if kcClient, ok := entry.meta.(*keycloak.KeycloakClient); ok {
 			keycloaksession.LogoutSession(ctx, entry.config, kcClient)
 		}
 		metaCache.Delete(key)

--- a/internal/tfconcurrency/pool.go
+++ b/internal/tfconcurrency/pool.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+// Package tfconcurrency makes the Terraform-Plugin-SDK no-fork execution path
+// safe for concurrent use in this provider.
+//
+// The embedded github.com/keycloak/terraform-provider-keycloak client
+// (*keycloak.KeycloakClient) is NOT safe for concurrent use: login(),
+// Refresh() and sendRequest() mutate shared fields (clientCredentials,
+// version, initialLogin) without synchronization, and the upstream Mutex
+// field is not wired into those paths. Because upjet shares a single cached
+// client (the provider "meta") across all concurrently reconciling managed
+// resources, concurrent operations race on that shared client and can crash
+// the provider with "fatal error: concurrent map writes".
+//
+// The terraform-plugin-sdk *schema.Resource itself IS safe for concurrent
+// use (Apply/RefreshWithoutUpgrade/Diff build fresh, local ResourceData and
+// deep-copy the schema before any mutation), so the only thing that must be
+// protected is the client. Rather than serializing everything behind a single
+// lock, this package gives each in-flight operation its OWN client borrowed
+// from a small, bounded, per-configuration pool. Concurrency is therefore
+// preserved up to the pool size while every client instance only ever has a
+// single user at a time.
+package tfconcurrency
+
+import (
+	"context"
+	"sync"
+
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+// ClientFactory creates a new, independent *keycloak.KeycloakClient for a
+// single provider configuration. Implementations typically build the client
+// exactly the way the provider setup does (same config, same login), so that
+// pooled clients are indistinguishable from the primary one.
+type ClientFactory func(ctx context.Context) (*keycloak.KeycloakClient, error)
+
+// Pool is a bounded pool of *keycloak.KeycloakClient instances that all target
+// the same provider configuration. At most Size clients are ever created and
+// at most Size operations run concurrently; additional borrowers block until a
+// client is returned (natural back-pressure). Clients are created lazily and
+// their creation is serialized to avoid a login/token "storm" against Keycloak.
+//
+// A borrowed client is used by exactly one goroutine for the duration of a
+// single, synchronous Terraform SDK callback, which is why per-client state
+// never races.
+type Pool struct {
+	// sem bounds the number of simultaneously-borrowed clients to the pool
+	// size. Acquiring a slot (sending) happens on Borrow; releasing (receiving)
+	// happens on Return.
+	sem chan struct{}
+
+	factory ClientFactory
+
+	// createMu serializes client construction so that a cold pool does not fire
+	// N concurrent logins at once.
+	createMu sync.Mutex
+
+	// mu guards idle and all.
+	mu   sync.Mutex
+	idle []*keycloak.KeycloakClient // returned clients available for reuse
+	all  []*keycloak.KeycloakClient // every client the pool owns (for Close)
+}
+
+// NewPool returns a pool that will hold at most size clients, created on
+// demand by factory. size is clamped to a minimum of 1.
+func NewPool(size int, factory ClientFactory) *Pool {
+	if size < 1 {
+		size = 1
+	}
+	return &Pool{
+		sem:     make(chan struct{}, size),
+		factory: factory,
+	}
+}
+
+// Seed adds an already-constructed client to the pool as an idle, reusable
+// member. It is used to donate the provider's primary (already logged-in)
+// client to the pool so it is not left idle. Seed does not consume a borrow
+// slot. It is a no-op for a nil client.
+func (p *Pool) Seed(c *keycloak.KeycloakClient) {
+	if p == nil || c == nil {
+		return
+	}
+	p.mu.Lock()
+	p.idle = append(p.idle, c)
+	p.all = append(p.all, c)
+	p.mu.Unlock()
+}
+
+// Borrow returns a client for exclusive use by the caller until Return is
+// called. It blocks if the pool is at capacity, returning early only if ctx is
+// cancelled. On any error the borrow slot is released so the pool does not leak
+// capacity.
+func (p *Pool) Borrow(ctx context.Context) (*keycloak.KeycloakClient, error) {
+	// Acquire a capacity slot (bounds concurrency to the pool size).
+	select {
+	case p.sem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+
+	// Reuse an idle client if one is available.
+	p.mu.Lock()
+	if n := len(p.idle); n > 0 {
+		c := p.idle[n-1]
+		p.idle[n-1] = nil
+		p.idle = p.idle[:n-1]
+		p.mu.Unlock()
+		return c, nil
+	}
+	p.mu.Unlock()
+
+	// None idle: create a new one (serialized). We hold the slot throughout, so
+	// the total number of clients can never exceed the pool size.
+	c, err := p.create(ctx)
+	if err != nil {
+		<-p.sem // release the slot we acquired
+		return nil, err
+	}
+	return c, nil
+}
+
+func (p *Pool) create(ctx context.Context) (*keycloak.KeycloakClient, error) {
+	p.createMu.Lock()
+	defer p.createMu.Unlock()
+
+	c, err := p.factory(ctx)
+	if err != nil {
+		return nil, err
+	}
+	p.mu.Lock()
+	p.all = append(p.all, c)
+	p.mu.Unlock()
+	return c, nil
+}
+
+// Return releases a previously borrowed client back to the pool for reuse and
+// frees a capacity slot. Returning a nil client only frees the slot.
+func (p *Pool) Return(c *keycloak.KeycloakClient) {
+	if c != nil {
+		p.mu.Lock()
+		p.idle = append(p.idle, c)
+		p.mu.Unlock()
+	}
+	<-p.sem
+}
+
+// Clients returns a snapshot of every client the pool owns. It is used for
+// lifecycle operations such as logout on shutdown.
+func (p *Pool) Clients() []*keycloak.KeycloakClient {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]*keycloak.KeycloakClient, len(p.all))
+	copy(out, p.all)
+	return out
+}

--- a/internal/tfconcurrency/pool_test.go
+++ b/internal/tfconcurrency/pool_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package tfconcurrency
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+// newOfflineClient builds a real *keycloak.KeycloakClient that performs no
+// network I/O: with no credentials and initialLogin=false the constructor skips
+// the login round-trip.
+func newOfflineClient(t *testing.T) *keycloak.KeycloakClient {
+	t.Helper()
+	c, err := newOfflineClientErr(context.Background())
+	if err != nil {
+		t.Fatalf("NewKeycloakClient: %v", err)
+	}
+	return c
+}
+
+func newOfflineClientErr(ctx context.Context) (*keycloak.KeycloakClient, error) {
+	return keycloak.NewKeycloakClient(
+		ctx,
+		"http://127.0.0.1:1", "", "", "admin-cli", "", "master",
+		"", "", "", "", "", "", "",
+		false, 5, "", true, "", "", "test", false, nil,
+	)
+}
+
+func offlineFactory() ClientFactory {
+	return func(ctx context.Context) (*keycloak.KeycloakClient, error) {
+		return newOfflineClientErr(ctx)
+	}
+}
+
+func TestPoolReusesReturnedClient(t *testing.T) {
+	p := NewPool(2, offlineFactory())
+	ctx := context.Background()
+
+	c1, err := p.Borrow(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.Return(c1)
+
+	c2, err := p.Borrow(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c1 != c2 {
+		t.Fatal("expected the returned client to be reused")
+	}
+	p.Return(c2)
+
+	if got := len(p.Clients()); got != 1 {
+		t.Fatalf("pool created %d clients, want 1", got)
+	}
+}
+
+func TestPoolBoundsToSize(t *testing.T) {
+	p := NewPool(2, offlineFactory())
+	ctx := context.Background()
+
+	c1, _ := p.Borrow(ctx)
+	c2, _ := p.Borrow(ctx)
+
+	res := make(chan *keycloak.KeycloakClient, 1)
+	go func() {
+		c, _ := p.Borrow(ctx)
+		res <- c
+	}()
+
+	select {
+	case <-res:
+		t.Fatal("third borrow should block while the pool is at capacity")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	p.Return(c1)
+	select {
+	case <-res:
+	case <-time.After(time.Second):
+		t.Fatal("third borrow should unblock after a return")
+	}
+	p.Return(c2)
+
+	if got := len(p.Clients()); got > 2 {
+		t.Fatalf("pool created %d clients, want <= 2", got)
+	}
+}
+
+func TestPoolBorrowRespectsContextCancellation(t *testing.T) {
+	p := NewPool(1, offlineFactory())
+	ctx := context.Background()
+
+	c1, _ := p.Borrow(ctx)
+	defer p.Return(c1)
+
+	cctx, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := p.Borrow(cctx); err == nil {
+		t.Fatal("expected Borrow to fail when context is cancelled and pool is saturated")
+	}
+}
+
+func TestPoolConcurrentBorrowReturn(t *testing.T) {
+	const size = 4
+	p := NewPool(size, offlineFactory())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 200; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c, err := p.Borrow(context.Background())
+			if err != nil {
+				return
+			}
+			time.Sleep(time.Millisecond)
+			p.Return(c)
+		}()
+	}
+	wg.Wait()
+
+	if got := len(p.Clients()); got > size {
+		t.Fatalf("pool created %d clients, want <= %d", got, size)
+	}
+}

--- a/internal/tfconcurrency/pool_test.go
+++ b/internal/tfconcurrency/pool_test.go
@@ -35,9 +35,7 @@ func newOfflineClientErr(ctx context.Context) (*keycloak.KeycloakClient, error) 
 }
 
 func offlineFactory() ClientFactory {
-	return func(ctx context.Context) (*keycloak.KeycloakClient, error) {
-		return newOfflineClientErr(ctx)
-	}
+	return newOfflineClientErr
 }
 
 func TestPoolReusesReturnedClient(t *testing.T) {

--- a/internal/tfconcurrency/wrap.go
+++ b/internal/tfconcurrency/wrap.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package tfconcurrency
+
+import (
+	"context"
+	"sync"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+// registry maps a provider's primary (cached) *keycloak.KeycloakClient — the
+// value upjet passes as the schema callback `meta` — to the per-configuration
+// Pool that backs it. It is populated by the provider setup for every unique
+// configuration.
+var registry sync.Map // map[*keycloak.KeycloakClient]*Pool
+
+// fallbackMu holds a per-client mutex used only when no pool is registered for
+// a given meta client (should not happen in production). It guarantees the
+// wrapped callbacks are still race-free (serialized) as a defensive fallback.
+var fallbackMu sync.Map // map[*keycloak.KeycloakClient]*sync.Mutex
+
+// Register associates a primary client (the schema callback meta) with its
+// pool. Both must be non-nil.
+func Register(meta *keycloak.KeycloakClient, p *Pool) {
+	if meta == nil || p == nil {
+		return
+	}
+	registry.Store(meta, p)
+}
+
+// Unregister removes the pool association for a primary client.
+func Unregister(meta *keycloak.KeycloakClient) {
+	if meta == nil {
+		return
+	}
+	registry.Delete(meta)
+	fallbackMu.Delete(meta)
+}
+
+func poolFor(meta any) *Pool {
+	kc, ok := meta.(*keycloak.KeycloakClient)
+	if !ok || kc == nil {
+		return nil
+	}
+	if v, ok := registry.Load(kc); ok {
+		return v.(*Pool)
+	}
+	return nil
+}
+
+// borrow selects the client a wrapped callback should use in place of the
+// shared meta. When a pool is registered it borrows a dedicated client (so the
+// callback runs concurrently with others, each on its own client). When no pool
+// is registered it returns the original meta guarded by a per-client mutex so
+// the callback is still serialized and therefore race-free. The returned
+// release function must always be called (defer) exactly once.
+func borrow(ctx context.Context, meta any) (client any, release func(), err error) {
+	if pool := poolFor(meta); pool != nil {
+		c, berr := pool.Borrow(ctx)
+		if berr != nil {
+			return nil, func() {}, berr
+		}
+		return c, func() { pool.Return(c) }, nil
+	}
+
+	kc, ok := meta.(*keycloak.KeycloakClient)
+	if !ok || kc == nil {
+		return meta, func() {}, nil
+	}
+	v, _ := fallbackMu.LoadOrStore(kc, &sync.Mutex{})
+	m := v.(*sync.Mutex)
+	m.Lock()
+	return meta, m.Unlock, nil
+}
+
+// WrapProvider wraps every resource and data source in p so that their
+// Terraform SDK callbacks run against a per-configuration pooled client instead
+// of the single shared meta client. It must be called on the same
+// *schema.Provider whose resources upjet drives at runtime.
+func WrapProvider(p *schema.Provider) {
+	if p == nil {
+		return
+	}
+	for _, r := range p.ResourcesMap {
+		WrapResource(r)
+	}
+	for _, r := range p.DataSourcesMap {
+		WrapResource(r)
+	}
+}
+
+// WrapResource wraps the context-aware CRUD, CustomizeDiff and import callbacks
+// of a single resource. Each wrapped callback borrows a dedicated client for
+// the (synchronous) duration of the call and substitutes it as the meta
+// argument. Because each upjet operation (Apply/RefreshWithoutUpgrade/Diff)
+// invokes exactly one such callback with no nesting, a single borrow per call
+// is deadlock-free. The deprecated non-context CRUD fields are not used by
+// terraform-provider-keycloak and are intentionally left untouched.
+func WrapResource(r *schema.Resource) {
+	if r == nil {
+		return
+	}
+
+	r.CreateContext = wrapContext(r.CreateContext)
+	r.ReadContext = wrapContext(r.ReadContext)
+	r.UpdateContext = wrapContext(r.UpdateContext)
+	r.DeleteContext = wrapContext(r.DeleteContext)
+
+	r.CreateWithoutTimeout = wrapContext(r.CreateWithoutTimeout)
+	r.ReadWithoutTimeout = wrapContext(r.ReadWithoutTimeout)
+	r.UpdateWithoutTimeout = wrapContext(r.UpdateWithoutTimeout)
+	r.DeleteWithoutTimeout = wrapContext(r.DeleteWithoutTimeout)
+
+	r.CustomizeDiff = wrapCustomizeDiff(r.CustomizeDiff)
+
+	if r.Importer != nil {
+		r.Importer.StateContext = wrapStateContext(r.Importer.StateContext)
+	}
+}
+
+// wrapContext wraps any context-aware CRUD callback. It uses the unnamed
+// underlying signature so the result is assignable to each of the distinct
+// named SDK types (CreateContextFunc, ReadContextFunc, ...).
+func wrapContext(orig func(context.Context, *schema.ResourceData, any) diag.Diagnostics) func(context.Context, *schema.ResourceData, any) diag.Diagnostics {
+	if orig == nil {
+		return nil
+	}
+	return func(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {
+		client, release, err := borrow(ctx, meta)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		defer release()
+		return orig(ctx, d, client)
+	}
+}
+
+func wrapCustomizeDiff(orig func(context.Context, *schema.ResourceDiff, any) error) func(context.Context, *schema.ResourceDiff, any) error {
+	if orig == nil {
+		return nil
+	}
+	return func(ctx context.Context, d *schema.ResourceDiff, meta any) error {
+		client, release, err := borrow(ctx, meta)
+		if err != nil {
+			return err
+		}
+		defer release()
+		return orig(ctx, d, client)
+	}
+}
+
+func wrapStateContext(orig func(context.Context, *schema.ResourceData, any) ([]*schema.ResourceData, error)) func(context.Context, *schema.ResourceData, any) ([]*schema.ResourceData, error) {
+	if orig == nil {
+		return nil
+	}
+	return func(ctx context.Context, d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+		client, release, err := borrow(ctx, meta)
+		if err != nil {
+			return nil, err
+		}
+		defer release()
+		return orig(ctx, d, client)
+	}
+}

--- a/internal/tfconcurrency/wrap_test.go
+++ b/internal/tfconcurrency/wrap_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package tfconcurrency
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/keycloak/terraform-provider-keycloak/keycloak"
+)
+
+func TestWrapResourceSubstitutesPooledClient(t *testing.T) {
+	primary := newOfflineClient(t)
+	pool := NewPool(2, offlineFactory())
+	Register(primary, pool)
+	defer Unregister(primary)
+
+	var got any
+	r := &schema.Resource{
+		ReadContext: func(_ context.Context, _ *schema.ResourceData, meta any) diag.Diagnostics {
+			got = meta
+			return nil
+		},
+	}
+	WrapResource(r)
+
+	if diags := r.ReadContext(context.Background(), nil, primary); diags.HasError() {
+		t.Fatalf("unexpected diags: %v", diags)
+	}
+
+	gotClient, ok := got.(*keycloak.KeycloakClient)
+	if !ok || gotClient == nil {
+		t.Fatalf("callback did not receive a *keycloak.KeycloakClient, got %T", got)
+	}
+	if gotClient == primary {
+		t.Fatal("callback received the shared primary client; expected a pooled substitute")
+	}
+}
+
+// TestWrapResourceAllowsBoundedConcurrency proves the fix preserves concurrency
+// (more than one callback runs at once) while bounding it to the pool size.
+func TestWrapResourceAllowsBoundedConcurrency(t *testing.T) {
+	const size = 3
+	primary := newOfflineClient(t)
+	pool := NewPool(size, offlineFactory())
+	Register(primary, pool)
+	defer Unregister(primary)
+
+	var active, maxActive int32
+	entered := make(chan struct{}, 16)
+	release := make(chan struct{})
+
+	r := &schema.Resource{
+		ReadContext: func(_ context.Context, _ *schema.ResourceData, _ any) diag.Diagnostics {
+			n := atomic.AddInt32(&active, 1)
+			for {
+				old := atomic.LoadInt32(&maxActive)
+				if n <= old || atomic.CompareAndSwapInt32(&maxActive, old, n) {
+					break
+				}
+			}
+			entered <- struct{}{}
+			<-release
+			atomic.AddInt32(&active, -1)
+			return nil
+		},
+	}
+	WrapResource(r)
+
+	const callers = 5
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.ReadContext(context.Background(), nil, primary)
+		}()
+	}
+
+	for i := 0; i < size; i++ {
+		select {
+		case <-entered:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("only %d/%d callbacks entered; expected %d concurrent", i, callers, size)
+		}
+	}
+	select {
+	case <-entered:
+		t.Fatal("more than pool-size callbacks ran concurrently")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	wg.Wait()
+
+	if maxActive != size {
+		t.Fatalf("max concurrent callbacks = %d, want %d", maxActive, size)
+	}
+}
+
+// TestWrapResourceNoRaceUnderConcurrentLogin drives many concurrent operations
+// that each trigger a login + request through the wrapper. With the shared
+// client this races on initialLogin/clientCredentials/version; with the pool
+// each operation uses its own client, so `go test -race` stays clean.
+func TestWrapResourceNoRaceUnderConcurrentLogin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/protocol/openid-connect/token"):
+			_, _ = w.Write([]byte(`{"access_token":"a","refresh_token":"r","token_type":"bearer","expires_in":300}`))
+		case strings.Contains(r.URL.Path, "/serverinfo"):
+			_, _ = w.Write([]byte(`{"systemInfo":{"version":"26.0.0"}}`))
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	defer srv.Close()
+
+	factory := func(ctx context.Context) (*keycloak.KeycloakClient, error) {
+		return keycloak.NewKeycloakClient(
+			ctx,
+			srv.URL, "", "", "admin-cli", "", "master",
+			"admin", "admin", "", "", "", "", "",
+			false, 5, "", true, "", "", "test", false, nil,
+		)
+	}
+
+	primary, err := factory(context.Background())
+	if err != nil {
+		t.Fatalf("factory: %v", err)
+	}
+	pool := NewPool(4, factory)
+	Register(primary, pool)
+	defer Unregister(primary)
+
+	r := &schema.Resource{
+		ReadContext: func(ctx context.Context, _ *schema.ResourceData, meta any) diag.Diagnostics {
+			kc := meta.(*keycloak.KeycloakClient)
+			if _, err := kc.GetServerInfo(ctx); err != nil {
+				return diag.FromErr(err)
+			}
+			return nil
+		},
+	}
+	WrapResource(r)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = r.ReadContext(context.Background(), nil, primary)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Problem

The provider crash-loops with `fatal error: concurrent map writes` (exit code 2) under load — e.g. a flood of ProtocolMapper reconciles — as reported in #555. That issue was closed by defaulting `--max-concurrent-reconciles=1`, which only masks the crash for same-kind reconciles; this PR fixes the underlying data race so concurrency is safe.

Root cause: the embedded `terraform-provider-keycloak` client (`*keycloak.KeycloakClient`) is **not safe for concurrent use**. `sendRequest`, `login` and `Refresh` mutate shared fields (`initialLogin`, `clientCredentials`, `version`) without synchronization, and the upstream `Mutex` field is never wired into those paths. upjet shares a single cached client (the provider `meta`) across all concurrently-reconciling managed resources, so concurrent operations race on it. `--max-concurrent-reconciles=1` does not cover upjet's async CRUD goroutines or the cross-kind controllers that all share the client.

The terraform-plugin-sdk `*schema.Resource` itself **is** safe for concurrent use (fresh per-call `ResourceData`, deep-copied schema before any mutation), so only the client needed protecting.

## Fix

Give each in-flight Terraform SDK callback its **own** client, borrowed from a small bounded **per-configuration pool** (`internal/tfconcurrency`), and substitute it as `meta`. Every callback site uses only `meta.(*keycloak.KeycloakClient)`, so substitution is transparent. Concurrency is preserved up to the pool size; each client instance only ever has one user at a time. Clients are created lazily with serialized construction (bounded logins, no token storm) and logged out on shutdown. The lower-volume identifying-properties lookup client is guarded with a per-config mutex.

### Behavioural change
- New flag `--keycloak-client-pool-size` (default `5`) bounds Keycloak connections per config — the effective ceiling on concurrent calls to a single Keycloak instance.
- `--max-concurrent-reconciles` default raised **1 → 5** (safe now that the client is pooled). Set it back to `1` to keep the old conservative behaviour.

## Evidence — Go race detector, before/after

Deterministic, CI-able proof — the authoritative guard for this class of bug (the production crash is timing-dependent).

**Before** — a single shared client used by 50 goroutines (the pre-fix behaviour):

```
WARNING: DATA RACE
Read at 0x00c0001485c0 by goroutine 12:
  keycloak.(*KeycloakClient).sendRequest()   keycloak_client.go:397   // if !keycloakClient.initialLogin
  keycloak.(*KeycloakClient).GetServerInfo() server_info.go:79
Previous write at 0x00c0001485c0 by goroutine 59:
  keycloak.(*KeycloakClient).sendRequest()   keycloak_client.go:398   // keycloakClient.initialLogin = true
  keycloak.(*KeycloakClient).GetServerInfo() server_info.go:79
--- FAIL: TestSharedClientRacesWithoutFix (0.01s)
    testing.go: race detected during execution of test
FAIL
```

**After** — the identical concurrent-login scenario routed through the fix (`make test.race`):

```
--- PASS: TestPoolReusesReturnedClient (0.00s)
--- PASS: TestPoolBoundsToSize (0.05s)
--- PASS: TestPoolBorrowRespectsContextCancellation (0.00s)
--- PASS: TestPoolConcurrentBorrowReturn (0.06s)
--- PASS: TestWrapResourceSubstitutesPooledClient (0.00s)
--- PASS: TestWrapResourceAllowsBoundedConcurrency (0.10s)   // proves >1 concurrency, bounded by pool size
--- PASS: TestWrapResourceNoRaceUnderConcurrentLogin (0.01s) // the "before" scenario, now clean
ok  github.com/crossplane-contrib/provider-keycloak/internal/tfconcurrency  2.291s
ok  github.com/crossplane-contrib/provider-keycloak/internal/clients        2.844s
ok  github.com/crossplane-contrib/provider-keycloak/config                  2.584s
```

Also green: `go build ./...`, `go vet`, `gofmt -l` (clean). Environment: `go1.26.4 darwin/arm64`, embedded `terraform-provider-keycloak v0.0.0-20260608085440-209a0abf877d`.

## Test plan

- `make test.race` — the committed race-detector suite shown above.
- `make test` — unit suite.
- Optional cluster load test: run with `--max-concurrent-reconciles=20 --keycloak-client-pool-size=8` and bulk-create ~300 same-kind MRs in one realm; expect no `concurrent map writes` and all `Synced=True`. Running the same flood against the pre-fix commit reproduces the crash (exit 2).
