### PR TITLE
feat/expose-realm-keystores

### DIFF
--- a/apis/cluster/realm/v1alpha1/zz_keystorersa_terraformed.go
+++ b/apis/cluster/realm/v1alpha1/zz_keystorersa_terraformed.go
@@ -12,118 +12,120 @@ import (
 
 	"github.com/crossplane/upjet/v2/pkg/resource"
 	"github.com/crossplane/upjet/v2/pkg/resource/json"
+	
 )
 
 // GetTerraformResourceType returns Terraform resource type for this KeystoreRsa
 func (mg *KeystoreRsa) GetTerraformResourceType() string {
-	return "keycloak_realm_keystore_rsa"
+    return "keycloak_realm_keystore_rsa"
 }
 
 // GetConnectionDetailsMapping for this KeystoreRsa
 func (tr *KeystoreRsa) GetConnectionDetailsMapping() map[string]string {
-	return map[string]string{"certificate": "certificateSecretRef", "private_key": "privateKeySecretRef"}
+  return map[string]string{ "certificate": "certificateSecretRef", "private_key": "privateKeySecretRef",  }
 }
 
 // GetObservation of this KeystoreRsa
 func (tr *KeystoreRsa) GetObservation() (map[string]any, error) {
-	o, err := json.TFParser.Marshal(tr.Status.AtProvider)
-	if err != nil {
-		return nil, err
-	}
-	base := map[string]any{}
-	return base, json.TFParser.Unmarshal(o, &base)
+    o, err := json.TFParser.Marshal(tr.Status.AtProvider)
+    if err != nil {
+        return nil, err
+    }
+    base := map[string]any{}
+    return base, json.TFParser.Unmarshal(o, &base)
 }
 
 // SetObservation for this KeystoreRsa
 func (tr *KeystoreRsa) SetObservation(obs map[string]any) error {
-	p, err := json.TFParser.Marshal(obs)
-	if err != nil {
-		return err
-	}
-	return json.TFParser.Unmarshal(p, &tr.Status.AtProvider)
+    p, err := json.TFParser.Marshal(obs)
+    if err != nil {
+        return err
+    }
+    return json.TFParser.Unmarshal(p, &tr.Status.AtProvider)
 }
 
 // GetID returns ID of underlying Terraform resource of this KeystoreRsa
 func (tr *KeystoreRsa) GetID() string {
-	if tr.Status.AtProvider.ID == nil {
-		return ""
-	}
-	return *tr.Status.AtProvider.ID
+    if tr.Status.AtProvider.ID == nil {
+        return ""
+    }
+    return *tr.Status.AtProvider.ID
 }
 
 // GetParameters of this KeystoreRsa
 func (tr *KeystoreRsa) GetParameters() (map[string]any, error) {
-	p, err := json.TFParser.Marshal(tr.Spec.ForProvider)
-	if err != nil {
-		return nil, err
-	}
-	base := map[string]any{}
-	return base, json.TFParser.Unmarshal(p, &base)
+    p, err := json.TFParser.Marshal(tr.Spec.ForProvider)
+    if err != nil {
+        return nil, err
+    }
+    base := map[string]any{}
+    return base, json.TFParser.Unmarshal(p, &base)
 }
 
 // SetParameters for this KeystoreRsa
 func (tr *KeystoreRsa) SetParameters(params map[string]any) error {
-	p, err := json.TFParser.Marshal(params)
-	if err != nil {
-		return err
-	}
-	return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
+    p, err := json.TFParser.Marshal(params)
+    if err != nil {
+        return err
+    }
+    return json.TFParser.Unmarshal(p, &tr.Spec.ForProvider)
 }
 
 // GetInitParameters of this KeystoreRsa
 func (tr *KeystoreRsa) GetInitParameters() (map[string]any, error) {
-	p, err := json.TFParser.Marshal(tr.Spec.InitProvider)
-	if err != nil {
-		return nil, err
-	}
-	base := map[string]any{}
-	return base, json.TFParser.Unmarshal(p, &base)
+    p, err := json.TFParser.Marshal(tr.Spec.InitProvider)
+    if err != nil {
+        return nil, err
+    }
+    base := map[string]any{}
+    return base, json.TFParser.Unmarshal(p, &base)
 }
 
 // GetInitParameters of this KeystoreRsa
 func (tr *KeystoreRsa) GetMergedParameters(shouldMergeInitProvider bool) (map[string]any, error) {
-	params, err := tr.GetParameters()
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot get parameters for resource \"%s/%s\"", tr.GetNamespace(), tr.GetName())
-	}
-	if !shouldMergeInitProvider {
-		return params, nil
-	}
+    params, err := tr.GetParameters()
+    if err != nil {
+        return nil, errors.Wrapf(err, "cannot get parameters for resource \"%s/%s\"", tr.GetNamespace(), tr.GetName())
+    }
+    if !shouldMergeInitProvider {
+        return params, nil
+    }
 
-	initParams, err := tr.GetInitParameters()
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot get init parameters for resource \"%s/%s\"", tr.GetNamespace(), tr.GetName())
-	}
+    initParams, err := tr.GetInitParameters()
+    if err != nil {
+        return nil, errors.Wrapf(err, "cannot get init parameters for resource \"%s/%s\"", tr.GetNamespace(), tr.GetName())
+    }
 
-	// Note(lsviben): mergo.WithSliceDeepCopy is needed to merge the
-	// slices from the initProvider to forProvider. As it also sets
-	// overwrite to true, we need to set it back to false, we don't
-	// want to overwrite the forProvider fields with the initProvider
-	// fields.
-	err = mergo.Merge(&params, initParams, mergo.WithSliceDeepCopy, func(c *mergo.Config) {
-		c.Overwrite = false
-	})
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot merge spec.initProvider and spec.forProvider parameters for resource \"%s/%s\"", tr.GetNamespace(), tr.GetName())
-	}
+    // Note(lsviben): mergo.WithSliceDeepCopy is needed to merge the
+    // slices from the initProvider to forProvider. As it also sets
+    // overwrite to true, we need to set it back to false, we don't
+    // want to overwrite the forProvider fields with the initProvider
+    // fields.
+    err = mergo.Merge(&params, initParams, mergo.WithSliceDeepCopy, func(c *mergo.Config) {
+        c.Overwrite = false
+    })
+    if err != nil {
+        return nil, errors.Wrapf(err, "cannot merge spec.initProvider and spec.forProvider parameters for resource \"%s/%s\"", tr.GetNamespace(), tr.GetName())
+    }
 
-	return params, nil
+    return params, nil
 }
 
 // LateInitialize this KeystoreRsa using its observed tfState.
 // returns True if there are any spec changes for the resource.
 func (tr *KeystoreRsa) LateInitialize(attrs []byte) (bool, error) {
-	params := &KeystoreRsaParameters{}
-	if err := json.TFParser.Unmarshal(attrs, params); err != nil {
-		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
-	}
-	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+    params := &KeystoreRsaParameters{}
+    if err := json.TFParser.Unmarshal(attrs, params); err != nil {
+        return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
+    }
+    opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+    
 
-	li := resource.NewGenericLateInitializer(opts...)
-	return li.LateInitialize(&tr.Spec.ForProvider, params)
+    li := resource.NewGenericLateInitializer(opts...)
+    return li.LateInitialize(&tr.Spec.ForProvider, params)
 }
 
 // GetTerraformSchemaVersion returns the associated Terraform schema version
 func (tr *KeystoreRsa) GetTerraformSchemaVersion() int {
-	return 0
+    return 0
 }

--- a/apis/cluster/realm/v1alpha1/zz_keystorersa_types.go
+++ b/apis/cluster/realm/v1alpha1/zz_keystorersa_types.go
@@ -11,160 +11,170 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	v1 "github.com/crossplane/crossplane-runtime/v2/apis/common/v1"
+v2 "github.com/crossplane/crossplane-runtime/v2/apis/common/v2"
+
 )
+
+
+
 
 type KeystoreRsaInitParameters struct {
 
-	// When false, key in not used for signing. Defaults to true.
-	// Set if the keys can be used for signing
-	Active *bool `json:"active,omitempty" tf:"active,omitempty"`
 
-	// Intended algorithm for the key. Defaults to RS256. Use RSA-OAEP for encryption keys
-	// Intended algorithm for the key
-	Algorithm *string `json:"algorithm,omitempty" tf:"algorithm,omitempty"`
+// When false, key in not used for signing. Defaults to true.
+// Set if the keys can be used for signing
+Active *bool `json:"active,omitempty" tf:"active,omitempty"`
 
-	// X509 Certificate encoded in PEM format.
-	// X509 Certificate encoded in PEM format
-	CertificateSecretRef v1.SecretKeySelector `json:"certificateSecretRef" tf:"-"`
+// Intended algorithm for the key. Defaults to RS256. Use RSA-OAEP for encryption keys
+// Intended algorithm for the key
+Algorithm *string `json:"algorithm,omitempty" tf:"algorithm,omitempty"`
 
-	// When false, key is not accessible in this realm. Defaults to true.
-	// Set if the keys are enabled
-	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
+// X509 Certificate encoded in PEM format.
+// X509 Certificate encoded in PEM format
+CertificateSecretRef v1.SecretKeySelector `json:"certificateSecretRef" tf:"-"`
 
-	// Map of additional provider configuration options passed through to the Keycloak component config. For RSA keystores this can include keys like kid.
-	// +mapType=granular
-	ExtraConfig map[string]*string `json:"extraConfig,omitempty" tf:"extra_config,omitempty"`
+// When false, key is not accessible in this realm. Defaults to true.
+// Set if the keys are enabled
+Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
 
-	// Display name of provider when linked in admin console.
-	// Display name of provider when linked in admin console.
-	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+// Map of additional provider configuration options passed through to the Keycloak component config. For RSA keystores this can include keys like kid.
+// +mapType=granular
+ExtraConfig map[string]*string `json:"extraConfig,omitempty" tf:"extra_config,omitempty"`
 
-	// Priority for the provider. Defaults to 0
-	// Priority for the provider
-	Priority *float64 `json:"priority,omitempty" tf:"priority,omitempty"`
+// Display name of provider when linked in admin console.
+// Display name of provider when linked in admin console.
+Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Private RSA Key encoded in PEM format.
-	// Private RSA Key encoded in PEM format
-	PrivateKeySecretRef v1.SecretKeySelector `json:"privateKeySecretRef" tf:"-"`
+// Priority for the provider. Defaults to 0
+// Priority for the provider
+Priority *float64 `json:"priority,omitempty" tf:"priority,omitempty"`
 
-	// Use rsa for signing keys, rsa-enc for encryption keys
-	// RSA key provider id
-	ProviderID *string `json:"providerId,omitempty" tf:"provider_id,omitempty"`
+// Private RSA Key encoded in PEM format.
+// Private RSA Key encoded in PEM format
+PrivateKeySecretRef v1.SecretKeySelector `json:"privateKeySecretRef" tf:"-"`
 
-	// The realm this keystore exists in.
-	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-keycloak/apis/cluster/realm/v1alpha1.Realm
-	RealmID *string `json:"realmId,omitempty" tf:"realm_id,omitempty"`
+// Use rsa for signing keys, rsa-enc for encryption keys
+// RSA key provider id
+ProviderID *string `json:"providerId,omitempty" tf:"provider_id,omitempty"`
 
-	// Reference to a Realm in realm to populate realmId.
-	// +kubebuilder:validation:Optional
-	RealmIDRef *v1.Reference `json:"realmIdRef,omitempty" tf:"-"`
+// The realm this keystore exists in.
+// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-keycloak/apis/cluster/realm/v1alpha1.Realm
+RealmID *string `json:"realmId,omitempty" tf:"realm_id,omitempty"`
 
-	// Selector for a Realm in realm to populate realmId.
-	// +kubebuilder:validation:Optional
-	RealmIDSelector *v1.Selector `json:"realmIdSelector,omitempty" tf:"-"`
+// Reference to a Realm in realm to populate realmId.
+// +kubebuilder:validation:Optional
+RealmIDRef *v1.Reference `json:"realmIdRef,omitempty" tf:"-"`
+
+// Selector for a Realm in realm to populate realmId.
+// +kubebuilder:validation:Optional
+RealmIDSelector *v1.Selector `json:"realmIdSelector,omitempty" tf:"-"`
 }
+
 
 type KeystoreRsaObservation struct {
 
-	// When false, key in not used for signing. Defaults to true.
-	// Set if the keys can be used for signing
-	Active *bool `json:"active,omitempty" tf:"active,omitempty"`
 
-	// Intended algorithm for the key. Defaults to RS256. Use RSA-OAEP for encryption keys
-	// Intended algorithm for the key
-	Algorithm *string `json:"algorithm,omitempty" tf:"algorithm,omitempty"`
+// When false, key in not used for signing. Defaults to true.
+// Set if the keys can be used for signing
+Active *bool `json:"active,omitempty" tf:"active,omitempty"`
 
-	// When false, key is not accessible in this realm. Defaults to true.
-	// Set if the keys are enabled
-	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
+// Intended algorithm for the key. Defaults to RS256. Use RSA-OAEP for encryption keys
+// Intended algorithm for the key
+Algorithm *string `json:"algorithm,omitempty" tf:"algorithm,omitempty"`
 
-	// Map of additional provider configuration options passed through to the Keycloak component config. For RSA keystores this can include keys like kid.
-	// +mapType=granular
-	ExtraConfig map[string]*string `json:"extraConfig,omitempty" tf:"extra_config,omitempty"`
+// When false, key is not accessible in this realm. Defaults to true.
+// Set if the keys are enabled
+Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
 
-	ID *string `json:"id,omitempty" tf:"id,omitempty"`
+// Map of additional provider configuration options passed through to the Keycloak component config. For RSA keystores this can include keys like kid.
+// +mapType=granular
+ExtraConfig map[string]*string `json:"extraConfig,omitempty" tf:"extra_config,omitempty"`
 
-	// Display name of provider when linked in admin console.
-	// Display name of provider when linked in admin console.
-	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+ID *string `json:"id,omitempty" tf:"id,omitempty"`
 
-	// Priority for the provider. Defaults to 0
-	// Priority for the provider
-	Priority *float64 `json:"priority,omitempty" tf:"priority,omitempty"`
+// Display name of provider when linked in admin console.
+// Display name of provider when linked in admin console.
+Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Use rsa for signing keys, rsa-enc for encryption keys
-	// RSA key provider id
-	ProviderID *string `json:"providerId,omitempty" tf:"provider_id,omitempty"`
+// Priority for the provider. Defaults to 0
+// Priority for the provider
+Priority *float64 `json:"priority,omitempty" tf:"priority,omitempty"`
 
-	// The realm this keystore exists in.
-	RealmID *string `json:"realmId,omitempty" tf:"realm_id,omitempty"`
+// Use rsa for signing keys, rsa-enc for encryption keys
+// RSA key provider id
+ProviderID *string `json:"providerId,omitempty" tf:"provider_id,omitempty"`
+
+// The realm this keystore exists in.
+RealmID *string `json:"realmId,omitempty" tf:"realm_id,omitempty"`
 }
+
 
 type KeystoreRsaParameters struct {
 
-	// When false, key in not used for signing. Defaults to true.
-	// Set if the keys can be used for signing
-	// +kubebuilder:validation:Optional
-	Active *bool `json:"active,omitempty" tf:"active,omitempty"`
 
-	// Intended algorithm for the key. Defaults to RS256. Use RSA-OAEP for encryption keys
-	// Intended algorithm for the key
-	// +kubebuilder:validation:Optional
-	Algorithm *string `json:"algorithm,omitempty" tf:"algorithm,omitempty"`
+// When false, key in not used for signing. Defaults to true.
+// Set if the keys can be used for signing
+// +kubebuilder:validation:Optional
+Active *bool `json:"active,omitempty" tf:"active,omitempty"`
 
-	// X509 Certificate encoded in PEM format.
-	// X509 Certificate encoded in PEM format
-	// +kubebuilder:validation:Optional
-	CertificateSecretRef v1.SecretKeySelector `json:"certificateSecretRef" tf:"-"`
+// Intended algorithm for the key. Defaults to RS256. Use RSA-OAEP for encryption keys
+// Intended algorithm for the key
+// +kubebuilder:validation:Optional
+Algorithm *string `json:"algorithm,omitempty" tf:"algorithm,omitempty"`
 
-	// When false, key is not accessible in this realm. Defaults to true.
-	// Set if the keys are enabled
-	// +kubebuilder:validation:Optional
-	Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
+// X509 Certificate encoded in PEM format.
+// X509 Certificate encoded in PEM format
+// +kubebuilder:validation:Optional
+CertificateSecretRef v1.SecretKeySelector `json:"certificateSecretRef" tf:"-"`
 
-	// Map of additional provider configuration options passed through to the Keycloak component config. For RSA keystores this can include keys like kid.
-	// +kubebuilder:validation:Optional
-	// +mapType=granular
-	ExtraConfig map[string]*string `json:"extraConfig,omitempty" tf:"extra_config,omitempty"`
+// When false, key is not accessible in this realm. Defaults to true.
+// Set if the keys are enabled
+// +kubebuilder:validation:Optional
+Enabled *bool `json:"enabled,omitempty" tf:"enabled,omitempty"`
 
-	// Display name of provider when linked in admin console.
-	// Display name of provider when linked in admin console.
-	// +kubebuilder:validation:Optional
-	Name *string `json:"name,omitempty" tf:"name,omitempty"`
+// Map of additional provider configuration options passed through to the Keycloak component config. For RSA keystores this can include keys like kid.
+// +kubebuilder:validation:Optional
+// +mapType=granular
+ExtraConfig map[string]*string `json:"extraConfig,omitempty" tf:"extra_config,omitempty"`
 
-	// Priority for the provider. Defaults to 0
-	// Priority for the provider
-	// +kubebuilder:validation:Optional
-	Priority *float64 `json:"priority,omitempty" tf:"priority,omitempty"`
+// Display name of provider when linked in admin console.
+// Display name of provider when linked in admin console.
+// +kubebuilder:validation:Optional
+Name *string `json:"name,omitempty" tf:"name,omitempty"`
 
-	// Private RSA Key encoded in PEM format.
-	// Private RSA Key encoded in PEM format
-	// +kubebuilder:validation:Optional
-	PrivateKeySecretRef v1.SecretKeySelector `json:"privateKeySecretRef" tf:"-"`
+// Priority for the provider. Defaults to 0
+// Priority for the provider
+// +kubebuilder:validation:Optional
+Priority *float64 `json:"priority,omitempty" tf:"priority,omitempty"`
 
-	// Use rsa for signing keys, rsa-enc for encryption keys
-	// RSA key provider id
-	// +kubebuilder:validation:Optional
-	ProviderID *string `json:"providerId,omitempty" tf:"provider_id,omitempty"`
+// Private RSA Key encoded in PEM format.
+// Private RSA Key encoded in PEM format
+// +kubebuilder:validation:Optional
+PrivateKeySecretRef v1.SecretKeySelector `json:"privateKeySecretRef" tf:"-"`
 
-	// The realm this keystore exists in.
-	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-keycloak/apis/cluster/realm/v1alpha1.Realm
-	// +kubebuilder:validation:Optional
-	RealmID *string `json:"realmId,omitempty" tf:"realm_id,omitempty"`
+// Use rsa for signing keys, rsa-enc for encryption keys
+// RSA key provider id
+// +kubebuilder:validation:Optional
+ProviderID *string `json:"providerId,omitempty" tf:"provider_id,omitempty"`
 
-	// Reference to a Realm in realm to populate realmId.
-	// +kubebuilder:validation:Optional
-	RealmIDRef *v1.Reference `json:"realmIdRef,omitempty" tf:"-"`
+// The realm this keystore exists in.
+// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-keycloak/apis/cluster/realm/v1alpha1.Realm
+// +kubebuilder:validation:Optional
+RealmID *string `json:"realmId,omitempty" tf:"realm_id,omitempty"`
 
-	// Selector for a Realm in realm to populate realmId.
-	// +kubebuilder:validation:Optional
-	RealmIDSelector *v1.Selector `json:"realmIdSelector,omitempty" tf:"-"`
+// Reference to a Realm in realm to populate realmId.
+// +kubebuilder:validation:Optional
+RealmIDRef *v1.Reference `json:"realmIdRef,omitempty" tf:"-"`
+
+// Selector for a Realm in realm to populate realmId.
+// +kubebuilder:validation:Optional
+RealmIDSelector *v1.Selector `json:"realmIdSelector,omitempty" tf:"-"`
 }
 
 // KeystoreRsaSpec defines the desired state of KeystoreRsa
 type KeystoreRsaSpec struct {
 	v1.ResourceSpec `json:",inline"`
-	ForProvider     KeystoreRsaParameters `json:"forProvider"`
+	ForProvider       KeystoreRsaParameters `json:"forProvider"`
 	// THIS IS A BETA FIELD. It will be honored
 	// unless the Management Policies feature flag is disabled.
 	// InitProvider holds the same fields as ForProvider, with the exception
@@ -175,20 +185,21 @@ type KeystoreRsaSpec struct {
 	// required on creation, but we do not desire to update them after creation,
 	// for example because of an external controller is managing them, like an
 	// autoscaler.
-	InitProvider KeystoreRsaInitParameters `json:"initProvider,omitempty"`
+	InitProvider       KeystoreRsaInitParameters `json:"initProvider,omitempty"`
 }
 
 // KeystoreRsaStatus defines the observed state of KeystoreRsa.
 type KeystoreRsaStatus struct {
 	v1.ResourceStatus `json:",inline"`
-	AtProvider        KeystoreRsaObservation `json:"atProvider,omitempty"`
+	AtProvider          KeystoreRsaObservation `json:"atProvider,omitempty"`
 }
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 
-// KeystoreRsa is the Schema for the KeystoreRsas API.
+
+// KeystoreRsa is the Schema for the KeystoreRsas API. 
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="EXTERNAL-NAME",type="string",JSONPath=".metadata.annotations.crossplane\\.io/external-name"
@@ -197,11 +208,11 @@ type KeystoreRsaStatus struct {
 type KeystoreRsa struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.certificateSecretRef)",message="spec.forProvider.certificateSecretRef is a required parameter"
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.privateKeySecretRef)",message="spec.forProvider.privateKeySecretRef is a required parameter"
-	Spec   KeystoreRsaSpec   `json:"spec"`
-	Status KeystoreRsaStatus `json:"status,omitempty"`
+// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.certificateSecretRef)",message="spec.forProvider.certificateSecretRef is a required parameter"
+// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.name) || (has(self.initProvider) && has(self.initProvider.name))",message="spec.forProvider.name is a required parameter"
+// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.privateKeySecretRef)",message="spec.forProvider.privateKeySecretRef is a required parameter"
+	Spec              KeystoreRsaSpec   `json:"spec"`
+	Status            KeystoreRsaStatus `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/internal/controller/cluster/realm/keystorersa/zz_controller.go
+++ b/internal/controller/cluster/realm/keystorersa/zz_controller.go
@@ -15,14 +15,16 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/reconciler/managed"
 	xpresource "github.com/crossplane/crossplane-runtime/v2/pkg/resource"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/statemetrics"
-	tjcontroller "github.com/crossplane/upjet/v2/pkg/controller"
 	"github.com/crossplane/upjet/v2/pkg/controller/handler"
+	tjcontroller "github.com/crossplane/upjet/v2/pkg/controller"
 	"github.com/crossplane/upjet/v2/pkg/metrics"
+	"github.com/crossplane/upjet/v2/pkg/terraform"
 	"github.com/pkg/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	v1alpha1 "github.com/crossplane-contrib/provider-keycloak/apis/cluster/realm/v1alpha1"
 	features "github.com/crossplane-contrib/provider-keycloak/internal/features"
+v1alpha1 "github.com/crossplane-contrib/provider-keycloak/apis/cluster/realm/v1alpha1"
+
 )
 
 // SetupWebhookWithManager registers the conversion webhook for KeystoreRsa.
@@ -52,21 +54,21 @@ func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	ac := tjcontroller.NewAPICallbacks(mgr, xpresource.ManagedKind(v1alpha1.KeystoreRsa_GroupVersionKind), tjcontroller.WithEventHandler(eventHandler), tjcontroller.WithStatusUpdates(false))
 	opts := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(
-			tjcontroller.NewTerraformPluginSDKAsyncConnector(mgr.GetClient(), o.OperationTrackerStore, o.SetupFn, o.Provider.Resources["keycloak_realm_keystore_rsa"],
-				tjcontroller.WithTerraformPluginSDKAsyncLogger(o.Logger),
-				tjcontroller.WithTerraformPluginSDKAsyncConnectorEventHandler(eventHandler),
-				tjcontroller.WithTerraformPluginSDKAsyncCallbackProvider(ac),
-				tjcontroller.WithTerraformPluginSDKAsyncMetricRecorder(metrics.NewMetricRecorder(v1alpha1.KeystoreRsa_GroupVersionKind, mgr, o.PollInterval)),
-				tjcontroller.WithTerraformPluginSDKAsyncManagementPolicies(o.Features.Enabled(features.EnableBetaManagementPolicies)))),
+              tjcontroller.NewTerraformPluginSDKAsyncConnector(mgr.GetClient(), o.OperationTrackerStore, o.SetupFn, o.Provider.Resources["keycloak_realm_keystore_rsa"],
+                tjcontroller.WithTerraformPluginSDKAsyncLogger(o.Logger),
+                tjcontroller.WithTerraformPluginSDKAsyncConnectorEventHandler(eventHandler),
+                tjcontroller.WithTerraformPluginSDKAsyncCallbackProvider(ac),
+                tjcontroller.WithTerraformPluginSDKAsyncMetricRecorder(metrics.NewMetricRecorder(v1alpha1.KeystoreRsa_GroupVersionKind, mgr, o.PollInterval)),
+                tjcontroller.WithTerraformPluginSDKAsyncManagementPolicies(o.Features.Enabled(features.EnableBetaManagementPolicies)))),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
 		managed.WithRecorder(event.NewAPIRecorder(mgr.GetEventRecorderFor(name))),
 		managed.WithFinalizer(tjcontroller.NewOperationTrackerFinalizer(o.OperationTrackerStore, xpresource.NewAPIFinalizer(mgr.GetClient(), managed.FinalizerName))),
-		managed.WithTimeout(3 * time.Minute),
+		managed.WithTimeout(3*time.Minute),
 		managed.WithInitializers(initializers),
 		managed.WithPollInterval(o.PollInterval),
 	}
 	if o.PollJitter != 0 {
-		opts = append(opts, managed.WithPollJitterHook(o.PollJitter))
+	    opts = append(opts, managed.WithPollJitterHook(o.PollJitter))
 	}
 	if o.Features.Enabled(features.EnableBetaManagementPolicies) {
 		opts = append(opts, managed.WithManagementPolicies())


### PR DESCRIPTION
## WHAT
- Expose additional realm/keystore-related resources and linked mapper coverage in this branch.

## WHY
- Improve resource coverage for realm and related identity-provider workflows.
- Provide CRDs users currently cannot manage directly.

## HOW
- Add resource configurations for the missing resources.
- Regenerate APIs, controllers, examples, and CRDs.

## EXAMPLES
- `examples-generated/cluster/realm/v1alpha1/*`
- `examples-generated/namespaced/realm/v1alpha1/*`

## ISSUES
- None linked.
