### PR TITLE
ci: add Keycloak 26.7.0 to e2e test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,6 +359,7 @@ jobs:
       fail-fast: false
       matrix:
         keycloak-version:
+          - '26.7.0'
           - '26.6.2'
           - '26.5.1'
           - '26.4.4'


### PR DESCRIPTION
## WHAT
- Update CI/e2e matrix to include Keycloak 26.7 support.

## WHY
- Keep CI coverage aligned with supported Keycloak versions.
- Validate compatibility with the latest target runtime version.

## HOW
- Update the CI matrix entry for e2e jobs to include Keycloak 26.7.
- Keep existing matrix combinations intact.

## EXAMPLES
- `.github/workflows/ci.yml`

## ISSUES
- Closes #635
