### PR TITLE
fix!(oidc,openidclient): type client_secret_wo_version as string

### DIFF
--- a/apis/cluster/oidc/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/oidc/v1alpha1/zz_generated.deepcopy.go
@@ -722,7 +722,7 @@ func (in *IdentityProviderInitParameters) DeepCopyInto(out *IdentityProviderInit
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultScopes != nil {
@@ -980,7 +980,7 @@ func (in *IdentityProviderObservation) DeepCopyInto(out *IdentityProviderObserva
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultScopes != nil {
@@ -1197,7 +1197,7 @@ func (in *IdentityProviderParameters) DeepCopyInto(out *IdentityProviderParamete
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultScopes != nil {

--- a/apis/cluster/oidc/v1alpha1/zz_identityprovider_types.go
+++ b/apis/cluster/oidc/v1alpha1/zz_identityprovider_types.go
@@ -52,7 +52,7 @@ type IdentityProviderInitParameters struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.
@@ -216,7 +216,7 @@ type IdentityProviderObservation struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.
@@ -380,7 +380,7 @@ type IdentityProviderParameters struct {
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
 	// +kubebuilder:validation:Optional
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.

--- a/apis/cluster/openidclient/v1alpha1/zz_client_types.go
+++ b/apis/cluster/openidclient/v1alpha1/zz_client_types.go
@@ -192,7 +192,7 @@ type ClientInitParameters struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// Time a client offline session is allowed to be idle before it expires. Offline tokens are invalidated when a client offline session is expired. If not set it uses the Offline Session Idle value.
 	ClientSessionIdleTimeout *string `json:"clientSessionIdleTimeout,omitempty" tf:"client_session_idle_timeout,omitempty"`
@@ -368,7 +368,7 @@ type ClientObservation struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// Time a client offline session is allowed to be idle before it expires. Offline tokens are invalidated when a client offline session is expired. If not set it uses the Offline Session Idle value.
 	ClientSessionIdleTimeout *string `json:"clientSessionIdleTimeout,omitempty" tf:"client_session_idle_timeout,omitempty"`
@@ -569,7 +569,7 @@ type ClientParameters struct {
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
 	// +kubebuilder:validation:Optional
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// Time a client offline session is allowed to be idle before it expires. Offline tokens are invalidated when a client offline session is expired. If not set it uses the Offline Session Idle value.
 	// +kubebuilder:validation:Optional

--- a/apis/cluster/openidclient/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/openidclient/v1alpha1/zz_generated.deepcopy.go
@@ -2415,7 +2415,7 @@ func (in *ClientInitParameters) DeepCopyInto(out *ClientInitParameters) {
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.ClientSessionIdleTimeout != nil {
@@ -2776,7 +2776,7 @@ func (in *ClientObservation) DeepCopyInto(out *ClientObservation) {
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.ClientSessionIdleTimeout != nil {
@@ -3367,7 +3367,7 @@ func (in *ClientParameters) DeepCopyInto(out *ClientParameters) {
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.ClientSessionIdleTimeout != nil {

--- a/apis/namespaced/oidc/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/oidc/v1alpha1/zz_generated.deepcopy.go
@@ -722,7 +722,7 @@ func (in *IdentityProviderInitParameters) DeepCopyInto(out *IdentityProviderInit
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultScopes != nil {
@@ -980,7 +980,7 @@ func (in *IdentityProviderObservation) DeepCopyInto(out *IdentityProviderObserva
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultScopes != nil {
@@ -1197,7 +1197,7 @@ func (in *IdentityProviderParameters) DeepCopyInto(out *IdentityProviderParamete
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.DefaultScopes != nil {

--- a/apis/namespaced/oidc/v1alpha1/zz_identityprovider_types.go
+++ b/apis/namespaced/oidc/v1alpha1/zz_identityprovider_types.go
@@ -53,7 +53,7 @@ type IdentityProviderInitParameters struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.
@@ -217,7 +217,7 @@ type IdentityProviderObservation struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.
@@ -381,7 +381,7 @@ type IdentityProviderParameters struct {
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
 	// +kubebuilder:validation:Optional
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
 	// The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to 'openid'.

--- a/apis/namespaced/openidclient/v1alpha1/zz_client_types.go
+++ b/apis/namespaced/openidclient/v1alpha1/zz_client_types.go
@@ -193,7 +193,7 @@ type ClientInitParameters struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// Time a client offline session is allowed to be idle before it expires. Offline tokens are invalidated when a client offline session is expired. If not set it uses the Offline Session Idle value.
 	ClientSessionIdleTimeout *string `json:"clientSessionIdleTimeout,omitempty" tf:"client_session_idle_timeout,omitempty"`
@@ -369,7 +369,7 @@ type ClientObservation struct {
 
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// Time a client offline session is allowed to be idle before it expires. Offline tokens are invalidated when a client offline session is expired. If not set it uses the Offline Session Idle value.
 	ClientSessionIdleTimeout *string `json:"clientSessionIdleTimeout,omitempty" tf:"client_session_idle_timeout,omitempty"`
@@ -570,7 +570,7 @@ type ClientParameters struct {
 	// The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
 	// Version of the Client secret write-only argument
 	// +kubebuilder:validation:Optional
-	ClientSecretWoVersion *float64 `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
+	ClientSecretWoVersion *string `json:"clientSecretWoVersion,omitempty" tf:"client_secret_wo_version,omitempty"`
 
 	// Time a client offline session is allowed to be idle before it expires. Offline tokens are invalidated when a client offline session is expired. If not set it uses the Offline Session Idle value.
 	// +kubebuilder:validation:Optional

--- a/apis/namespaced/openidclient/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/openidclient/v1alpha1/zz_generated.deepcopy.go
@@ -2415,7 +2415,7 @@ func (in *ClientInitParameters) DeepCopyInto(out *ClientInitParameters) {
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.ClientSessionIdleTimeout != nil {
@@ -2776,7 +2776,7 @@ func (in *ClientObservation) DeepCopyInto(out *ClientObservation) {
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.ClientSessionIdleTimeout != nil {
@@ -3367,7 +3367,7 @@ func (in *ClientParameters) DeepCopyInto(out *ClientParameters) {
 	}
 	if in.ClientSecretWoVersion != nil {
 		in, out := &in.ClientSecretWoVersion, &out.ClientSecretWoVersion
-		*out = new(float64)
+		*out = new(string)
 		**out = **in
 	}
 	if in.ClientSessionIdleTimeout != nil {

--- a/config/oidc/config.go
+++ b/config/oidc/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak"
 
 	"github.com/crossplane-contrib/provider-keycloak/config/common"
@@ -31,6 +32,11 @@ func Configure(p *config.Provider) {
 		}
 		if s, ok := r.TerraformResource.Schema["client_secret"]; ok {
 			s.Sensitive = true
+		}
+		// schema.json types this as a number, but the runtime provider stores it as
+		// a string; force string so late-init can unmarshal state (readNumberAsString).
+		if s, ok := r.TerraformResource.Schema["client_secret_wo_version"]; ok {
+			s.Type = schema.TypeString
 		}
 	})
 

--- a/config/openidclient/config.go
+++ b/config/openidclient/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/crossplane/upjet/v2/pkg/config"
 	n "github.com/crossplane/upjet/v2/pkg/types/name"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/keycloak/terraform-provider-keycloak/keycloak"
 
 	"github.com/crossplane-contrib/provider-keycloak/config/common"
@@ -111,6 +112,12 @@ func Configure(p *config.Provider) {
 				"valid_redirect_uris",
 				"web_origins",
 			},
+		}
+
+		// schema.json types this as a number, but the runtime provider stores it as
+		// a string; force string so late-init can unmarshal state (readNumberAsString).
+		if s, ok := r.TerraformResource.Schema["client_secret_wo_version"]; ok {
+			s.Type = schema.TypeString
 		}
 
 		// Publish the client's credentials as connection details.

--- a/config/wo_version_test.go
+++ b/config/wo_version_test.go
@@ -1,0 +1,53 @@
+package config
+
+import (
+	"testing"
+
+	ujconfig "github.com/crossplane/upjet/v2/pkg/config"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestClientSecretWoVersionIsString locks in the client_secret_wo_version type
+// override. The embedded generation schema (config/schema.json, dumped from an
+// older published provider release) types this field as a number, while the
+// runtime terraform-provider-keycloak SDK declares it schema.TypeString and
+// stores it in Terraform state as a quoted string. Without the override, upjet
+// generates a *float64 field and late-initialization fails to unmarshal the
+// observed state ("readNumberAsString: invalid number"), stalling every
+// reconcile of these resources at observe.
+func TestClientSecretWoVersionIsString(t *testing.T) {
+	resources := []string{
+		"keycloak_oidc_identity_provider",
+		"keycloak_openid_client",
+	}
+
+	flavours := map[string]func() (*ujconfig.Provider, error){
+		"cluster":    func() (*ujconfig.Provider, error) { return GetProvider(true) },
+		"namespaced": func() (*ujconfig.Provider, error) { return GetProviderNamespaced(true) },
+	}
+
+	for flavourName, get := range flavours {
+		t.Run(flavourName, func(t *testing.T) {
+			p, err := get()
+			if err != nil {
+				t.Fatalf("loading provider: %v", err)
+			}
+			for _, tfName := range resources {
+				r, ok := p.Resources[tfName]
+				if !ok {
+					t.Errorf("%s: resource not registered in provider", tfName)
+					continue
+				}
+				s, ok := r.TerraformResource.Schema["client_secret_wo_version"]
+				if !ok {
+					t.Errorf("%s: client_secret_wo_version not present in schema", tfName)
+					continue
+				}
+				if s.Type != schema.TypeString {
+					t.Errorf("%s: client_secret_wo_version type = %v, want %v — a number type makes late-init fail with readNumberAsString on the string state value",
+						tfName, s.Type, schema.TypeString)
+				}
+			}
+		})
+	}
+}

--- a/package/crds/oidc.keycloak.crossplane.io_identityproviders.yaml
+++ b/package/crds/oidc.keycloak.crossplane.io_identityproviders.yaml
@@ -161,7 +161,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   defaultScopes:
                     description: |-
                       The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
@@ -630,7 +630,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   defaultScopes:
                     description: |-
                       The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
@@ -1138,7 +1138,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   defaultScopes:
                     description: |-
                       The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.

--- a/package/crds/oidc.keycloak.m.crossplane.io_identityproviders.yaml
+++ b/package/crds/oidc.keycloak.m.crossplane.io_identityproviders.yaml
@@ -132,7 +132,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   defaultScopes:
                     description: |-
                       The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
@@ -604,7 +604,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   defaultScopes:
                     description: |-
                       The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.
@@ -1102,7 +1102,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   defaultScopes:
                     description: |-
                       The scopes to be sent when asking for authorization. It can be a space-separated list of scopes. Defaults to openid.

--- a/package/crds/openidclient.keycloak.crossplane.io_clients.yaml
+++ b/package/crds/openidclient.keycloak.crossplane.io_clients.yaml
@@ -374,7 +374,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   clientSessionIdleTimeout:
                     description: Time a client offline session is allowed to be idle
                       before it expires. Offline tokens are invalidated when a client
@@ -938,7 +938,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   clientSessionIdleTimeout:
                     description: Time a client offline session is allowed to be idle
                       before it expires. Offline tokens are invalidated when a client
@@ -1398,7 +1398,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   clientSessionIdleTimeout:
                     description: Time a client offline session is allowed to be idle
                       before it expires. Offline tokens are invalidated when a client

--- a/package/crds/openidclient.keycloak.m.crossplane.io_clients.yaml
+++ b/package/crds/openidclient.keycloak.m.crossplane.io_clients.yaml
@@ -362,7 +362,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   clientSessionIdleTimeout:
                     description: Time a client offline session is allowed to be idle
                       before it expires. Offline tokens are invalidated when a client
@@ -934,7 +934,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   clientSessionIdleTimeout:
                     description: Time a client offline session is allowed to be idle
                       before it expires. Offline tokens are invalidated when a client
@@ -1372,7 +1372,7 @@ spec:
                     description: |-
                       The value of this argument is stored in the state and plan files. Required when using client_secret_wo.
                       Version of the Client secret write-only argument
-                    type: number
+                    type: string
                   clientSessionIdleTimeout:
                     description: Time a client offline session is allowed to be idle
                       before it expires. Offline tokens are invalidated when a client


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
The embedded generation schema types client_secret_wo_version as a number, while the runtime terraform-provider-keycloak SDK declares it as schema.TypeString and stores it in Terraform state as a quoted string.

That generation/runtime drift makes upjet late-initialization fail to unmarshal the observed state into the generated *float64 field:

  observe failed: cannot late-initialize the managed resource: failed to
  unmarshal Terraform state parameters for late-initialization:
  ClientSecretWoVersion: readNumberAsString: invalid number

Every reconcile of keycloak_oidc_identity_provider and keycloak_openid_client resources that use the write-only client secret then stalls at observe, so a rotated client_secret_wo is never pushed to Keycloak (Synced=False, Ready=True).

Force the field to schema.TypeString in the resource configurators so the generated type matches what the provider actually stores. The override is a no-op at runtime, where the field is already TypeString. Regenerated types, deepcopy and CRDs accordingly, and added a config regression test.

**This PR Contains a breaking change as ClientSecretWoVersion is switched from int to string**

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
