### PR TITLE
fix(provider): qps + cache sync

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	ctrlconfig "sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
@@ -72,6 +73,9 @@ func main() {
 		leaderElection          = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
 		maxConcurrentReconciles = app.Flag("max-concurrent-reconciles", "The maximum number of concurrent reconcile operations per controller.").Default("5").Int()
+		kubeClientQPS           = app.Flag("kube-client-qps", "The client-side QPS limit for requests to the Kubernetes API server. The client-go default of 5 is too low to sync the informers of all managed resource kinds in time.").Default("50").Envar("KUBE_CLIENT_QPS").Float64()
+		kubeClientBurst         = app.Flag("kube-client-burst", "The client-side burst limit for requests to the Kubernetes API server.").Default("300").Envar("KUBE_CLIENT_BURST").Int()
+		cacheSyncTimeout        = app.Flag("cache-sync-timeout", "The per-controller timeout for waiting for the informer caches to sync, such as 2m or 10m.").Default("10m").Envar("CACHE_SYNC_TIMEOUT").Duration()
 		keycloakClientPoolSize  = app.Flag("keycloak-client-pool-size", "The maximum number of Keycloak client connections created per provider configuration to serve concurrent operations safely.").Default("5").Int()
 		webhookPort             = app.Flag("webhook-port", "The port the webhook listens on").Default("9443").Envar("WEBHOOK_PORT").Int()
 		metricsBindAddress      = app.Flag("metrics-bind-address", "The address the metrics server listens on").Default(":8080").Envar("METRICS_BIND_ADDRESS").String()
@@ -119,6 +123,11 @@ func main() {
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
+	// The client-go defaults (QPS 5, burst 10) cannot serve the initial
+	// list/watch storm of the informers for all managed resource kinds
+	// within the cache sync timeout.
+	cfg.QPS = float32(*kubeClientQPS)
+	cfg.Burst = *kubeClientBurst
 
 	// Get the TLS certs directory from the environment variables set by
 	// Crossplane if they're available.
@@ -147,6 +156,9 @@ func main() {
 		LeaderElectionID: "crossplane-leader-election-provider-keycloak",
 		Cache: cache.Options{
 			SyncPeriod: syncPeriod,
+		},
+		Controller: ctrlconfig.Controller{
+			CacheSyncTimeout: *cacheSyncTimeout,
 		},
 		Metrics: metricsserver.Options{
 			BindAddress: *metricsBindAddress,

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -73,8 +73,6 @@ func main() {
 		leaderElection          = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("10").Int()
 		maxConcurrentReconciles = app.Flag("max-concurrent-reconciles", "The maximum number of concurrent reconcile operations per controller.").Default("5").Int()
-		kubeClientQPS           = app.Flag("kube-client-qps", "The client-side QPS limit for requests to the Kubernetes API server. The client-go default of 5 is too low to sync the informers of all managed resource kinds in time.").Default("50").Envar("KUBE_CLIENT_QPS").Float64()
-		kubeClientBurst         = app.Flag("kube-client-burst", "The client-side burst limit for requests to the Kubernetes API server.").Default("300").Envar("KUBE_CLIENT_BURST").Int()
 		cacheSyncTimeout        = app.Flag("cache-sync-timeout", "The per-controller timeout for waiting for the informer caches to sync, such as 2m or 10m.").Default("10m").Envar("CACHE_SYNC_TIMEOUT").Duration()
 		keycloakClientPoolSize  = app.Flag("keycloak-client-pool-size", "The maximum number of Keycloak client connections created per provider configuration to serve concurrent operations safely.").Default("5").Int()
 		webhookPort             = app.Flag("webhook-port", "The port the webhook listens on").Default("9443").Envar("WEBHOOK_PORT").Int()
@@ -123,11 +121,6 @@ func main() {
 
 	cfg, err := ctrl.GetConfig()
 	kingpin.FatalIfError(err, "Cannot get API server rest config")
-	// The client-go defaults (QPS 5, burst 10) cannot serve the initial
-	// list/watch storm of the informers for all managed resource kinds
-	// within the cache sync timeout.
-	cfg.QPS = float32(*kubeClientQPS)
-	cfg.Burst = *kubeClientBurst
 
 	// Get the TLS certs directory from the environment variables set by
 	// Crossplane if they're available.
@@ -151,7 +144,10 @@ func main() {
 		}
 	}
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+	// LimitRESTConfig raises the client-go rate limits (QPS 5, burst 10 by
+	// default), which cannot serve the initial list/watch storm of the
+	// informers for all managed resource kinds within the cache sync timeout.
+	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		LeaderElection:   *leaderElection,
 		LeaderElectionID: "crossplane-leader-election-provider-keycloak",
 		Cache: cache.Options{


### PR DESCRIPTION
Fixes #729

## Description of your changes

Fixes the scale-dependent startup crashloop reported in #669 (comment by @michvllni): the provider exits after ~123s with `failed to wait for ... caches to sync`, taking the conversion webhook down with it and making resources stored at old API versions (`oidc/IdentityProvider` at `v1alpha1`) unreadable cluster-wide.

### Root cause

The rest config was used with client-go defaults (QPS 5, burst 10). Since v3 registers both the cluster-scoped and namespaced API trees, the manager cache starts ~223 informers, each issuing LIST+WATCH — 450+ requests through a 5 req/s client-side limiter takes longer than the fixed 2-minute controller-runtime cache sync timeout once there are enough objects. Conversion-backed kinds make it worse: their LISTs fail until the pod's own webhook serves, and every retry burns more rate-limiter tokens. A single controller hitting the timeout stops the whole manager, including the webhook server, and the crashloop re-enters the same race on every restart.

This is a known problem class — see Crossplane's [CRD scaling one-pager](https://github.com/crossplane/crossplane/blob/main/design/one-pager-crd-scaling.md#client-side-throttling): with ~192 GVs a burst of 300 was needed to avoid client-side throttling; provider-keycloak's ~223 GVKs sit right in that range.

### Changes

- Wrap the rest config with [`ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate)`](https://github.com/crossplane/crossplane-runtime/blob/master/pkg/ratelimiter/default.go) — QPS = rate×5, burst = rate×10, i.e. 50/100 with the default `--max-reconcile-rate=10`. This is the pattern mandated by Crossplane's [rate-limiting one-pager](https://github.com/crossplane/crossplane/blob/main/design/one-pager-rate-limiting.md#crossplane-rate-limits) ("provider maintainers must use the functions defined in `default.go`") and used by every provider-upjet-aws entry point, e.g. [`cmd/provider/monolith/zz_main.go`](https://github.com/crossplane-contrib/provider-upjet-aws/blob/main/cmd/provider/monolith/zz_main.go). provider-keycloak already used `ratelimiter.NewGlobal` (workqueue level) but had lost the client-level wrapper.
- Add `--cache-sync-timeout` (default 10m, env `CACHE_SYNC_TIMEOUT`), wired into the manager's global `Controller.CacheSyncTimeout`. Other providers don't set this because their clients aren't throttled to 5 QPS in the first place; it's kept here as headroom for the conversion-webhook self-dependency during v2→v3 upgrades (the ~60s window before the pod's own webhook serves counts against the sync deadline).

Not addressed: keeping the conversion webhook serving when a controller fails — a runnable error always stops the entire controller-runtime manager, so that would need a separate server/manager. With the sync timeout no longer being hit, that outage path shouldn't trigger in practice.

## I have:
- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

## How has this code been tested

`go build` / `go vet` / unit tests. Not yet verified against a large (~200 MR) installation — @michvllni offered to test. With QPS 50 / burst 100 the initial list dispatch completes in a few seconds instead of ~90s.

