### PR TITLE
Fix/conversion problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -582,6 +582,16 @@ jobs:
       - name: Set kind cluster as context
         run: kind export kubeconfig --name fenrir-1
 
+      - name: Running CRD Conversion Webhook Tests
+        id: conversionTests
+        if: matrix.keycloak-version == '26.7.0'
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail;
+          make uptest-conversion | tee logs/uptest-conversion.log;
+          exit $?;
+
       - name: Running E2E Tests
         id: e2eTests
         continue-on-error: true
@@ -602,17 +612,21 @@ jobs:
           fi
 
       - name: Collect logs
-        if: steps.e2eTests.outcome == 'failure'
+        if: steps.e2eTests.outcome == 'failure' || steps.conversionTests.outcome == 'failure'
         shell: bash
         run: ./dev/collect-logs.sh
 
       - name: Upload logs
-        if: steps.e2eTests.outcome == 'failure'
+        if: steps.e2eTests.outcome == 'failure' || steps.conversionTests.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: e2e-logs-${{ matrix.keycloak-version }}
           path: |
             logs/
+
+      - name: Fail on conversion webhook test error
+        if: steps.conversionTests.outcome == 'failure'
+        run: exit 1
 
       - name: Fail on error
         if: steps.e2eTests.outcome == 'failure'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,9 +257,16 @@ Rules and gotchas:
 
 ## Testing
 
+- **Before every commit** run `make lint` (golangci-lint, same config as CI —
+  includes checks like `nilerr` that `go build`/`go vet` do not catch) and
+  `go mod tidy` when imports changed (CI runs `make vendor.check`).
 - Unit tests: `make test`
 - E2E tests: `make e2e` (requires a running Keycloak and Crossplane cluster)
 - E2E coverage is limited to resources listed in `cluster/test/cases.txt`
+- CRD conversion regression tests: `make uptest-conversion` (chainsaw suite in
+  `cluster/test/conversion/` posting ConversionReview payloads to the live
+  `/convert` endpoint; covers stored encodings that can no longer be created
+  through the current CRD schemas, see #669).
 
 ### E2E suites
 
@@ -309,6 +316,13 @@ make docs-freshness-check             # CI: verify llms.txt is current
 
 ## Known Constraints and Pitfalls
 
+- **Always run `make lint` before committing.** CI runs golangci-lint v2 with
+  linters (e.g. `nilerr`) that a plain build never surfaces; pushing unlinted
+  code reliably fails the `lint` job.
+- **Chainsaw `script` steps run under `/usr/bin/sh` (dash), not bash.** No
+  bashisms: `set -o pipefail` is an illegal option there — use `set -eu` and
+  POSIX syntax only. Standalone helper scripts invoked from a step may use
+  bash via their own shebang.
 - Do **not** edit `examples-generated/` by hand.
 - Do **not** edit generated files in `apis/` or `package/crds/` by hand.
 - Do **not** edit `config/generated.lst` by hand — run `make generated-lst`

--- a/Makefile
+++ b/Makefile
@@ -301,6 +301,19 @@ uptest: $(UPTEST) $(KUBECTL) $(CHAINSAW) $(CROSSPLANE_CLI)
 	@KUBECTL=$(KUBECTL) CHAINSAW=$(CHAINSAW) CROSSPLANE_CLI=$(CROSSPLANE_CLI) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e "$(UPTEST_EXAMPLE_LIST)" $(RENDER_ONLY_FLAG) --data-source="${UPTEST_DATASOURCE_PATH}" --setup-script=cluster/test/setup.sh --default-conditions="Test" --default-timeout=2400s || $(FAIL)
 	@$(OK) running automated tests
 
+# The CRD conversion regression tests post ConversionReview payloads with the
+# historic stored encodings of clientSecretWoVersion (including the string
+# encoding persisted at v1alpha1 by pre-v3.0.0 builds, #669) directly to the
+# provider's live /convert endpoint, because the current CRD schemas no longer
+# admit such objects through the API server. Requires a cluster with the
+# provider deployed, i.e. the same prerequisites as the `uptest` target.
+uptest-conversion: $(CHAINSAW) $(KUBECTL)
+	@$(INFO) running CRD conversion webhook tests
+	@KUBECTL=$(KUBECTL) $(CHAINSAW) test --test-dir cluster/test/conversion || $(FAIL)
+	@$(OK) running CRD conversion webhook tests
+
+e2e-conversion: local-deploy uptest-conversion
+
 # Two gates: every demo file is listed in a case file, and every managed
 # resource has an e2e demo (or a documented exception in
 # cluster/test/uncovered-resources.txt).

--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,47 @@
+# fix(conversion): tolerate string `clientSecretWoVersion` at v1alpha1 and isolate controller startup failures
+
+Fixes the `v3.0.0-rc.1` crash-loop root-caused in #669 ([comment](https://github.com/crossplane-contrib/provider-keycloak/issues/669#issuecomment-5354284253)).
+
+## Problem
+
+Main builds between the terraform-provider v5.9.0 bump (588b321, Aug 6) and the v1alpha2 split (990f048, Aug 10) typed `clientSecretWoVersion` as a **string in v1alpha1** and persisted such objects. v3 re-freezes v1alpha1 as `number`, so the conversion webhook's strict typed decode fails on those stored objects:
+
+```
+conversion webhook for oidc.keycloak.m.crossplane.io/v1alpha1, Kind=IdentityProvider failed:
+json: cannot unmarshal string into Go struct field
+  IdentityProviderParameters.spec.forProvider.clientSecretWoVersion of type float64
+```
+
+Every LIST of that kind then 500s, the informer never syncs, and controller-runtime's all-or-nothing `WaitForCacheSync` kills the whole manager at the cache-sync deadline — taking the conversion webhook down with it, which makes the affected objects unreadable via the API entirely. Only clusters with objects stored during that 4-day window are affected, which is why fresh installs test green.
+
+The failure happens in the webhook's typed decode, **before** upjet's conversion chain (`RoundTrip`/`fieldTypeConverter`) runs, so no `config/conversion` registration can fix it.
+
+## Changes
+
+### 1. Tolerant decode of the string encoding (primary fix)
+
+Hand-written `UnmarshalJSON` on the frozen v1alpha1 `Parameters`/`InitParameters`/`Observation` structs of `oidc/IdentityProvider` and `openidclient/Client` (cluster + namespaced) coerces a string-encoded `clientSecretWoVersion` to the numeric encoding before default decoding.
+
+- Honored on both relevant paths: the webhook codec (sigs.k8s.io/json) and apimachinery's `FromUnstructured` used inside upjet's `RoundTrip`.
+- Non-numeric strings (e.g. `"version1"`, representable in the string-window schema but not as a number) fail with a descriptive error instead of being silently dropped.
+- Hand-written files in frozen spoke packages survive `make generate` (only `zz_generated.conversion_*`/`zz_generated.resolvers.go` are regenerated).
+
+### 2. Controller startup isolation (hardening)
+
+`internal/resilience.WrapManager` wraps the manager passed to the controller `Setup`/`SetupGated` calls: a controller whose `Start` fails (e.g. cache-sync timeout on an un-listable kind) is logged and dropped instead of aborting the manager.
+
+- Only runnables implementing `controller.Controller` are wrapped; the webhook server, cache, CRD gate, metrics recorders and session cleanup keep fatal semantics.
+- Shutdown-path errors still propagate; `NeedLeaderElection` is forwarded so runnable-group scheduling is unchanged.
+- Failed controllers cannot be restarted in controller-runtime, so the log message states the kind stays unreconciled until the provider restarts.
+
+Worst case degrades from "provider crash-loops, webhook-backed kinds unreadable, login flow outage" to "one controller idles, everything else including the conversion webhook keeps serving".
+
+## Tests
+
+- `config/conversion_test.go`: string-encoded stored v1alpha1 `Client`/`IdentityProvider` objects decode and upgrade to v1alpha2 through the real webhook code path; non-numeric strings are rejected with a descriptive error.
+- `internal/resilience/manager_test.go`: startup failure swallowed, shutdown error propagated, success passthrough, leader-election forwarding.
+- `cluster/test/conversion/` (e2e, `make uptest-conversion`, runs in the `26.7.0` CI matrix leg): the stored encodings can no longer be created through the fixed CRD schemas, so the chainsaw suite posts `ConversionReview` payloads directly to the provider's live `/convert` endpoint (service coordinates + caBundle read from the CRD, proving the package-manager injection). Covers the pre-v3.0.0 string encoding on all 4 webhook CRDs, the v2.x number encoding, the downgrade path, and malformed objects (non-numeric string, structurally broken spec) failing gracefully per-request with the webhook surviving.
+
+## Notes for affected clusters
+
+Clusters already broken on the rc can't `kubectl patch` (reads go through conversion) — upgrading to a build with this fix is sufficient: the decode succeeds, objects convert and get re-persisted at v1alpha2.

--- a/apis/cluster/oidc/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/cluster/oidc/v1alpha1/clientsecretwoversion_decode.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// coerceClientSecretWoVersion rewrites a string-encoded clientSecretWoVersion
+// to the number encoding of this frozen API version. Main builds between the
+// terraform-provider-keycloak v5.9.0 bump (588b321) and the v1alpha2 split
+// (990f048) typed the field as a string at v1alpha1 and persisted such values,
+// which would otherwise fail the strict decode in the conversion webhook and
+// crash-loop the provider (see crossplane-contrib/provider-keycloak#669).
+func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	raw, ok := obj["clientSecretWoVersion"]
+	if !ok {
+		return data, nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
+		// Not a string, let the default decoding handle it.
+		return data, nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+	}
+	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+	return json.Marshal(obj)
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *IdentityProviderParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods IdentityProviderParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *IdentityProviderInitParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods IdentityProviderInitParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *IdentityProviderObservation) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods IdentityProviderObservation
+	return json.Unmarshal(data, (*noMethods)(in))
+}

--- a/apis/cluster/oidc/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/cluster/oidc/v1alpha1/clientsecretwoversion_decode.go
@@ -26,16 +26,16 @@ func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
 		return data, nil
 	}
 	var s string
-	if json.Unmarshal(raw, &s) != nil {
-		// Not a string, let the default decoding handle it.
-		return data, nil
+	if json.Unmarshal(raw, &s) == nil {
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+		}
+		obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+		return json.Marshal(obj)
 	}
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
-	}
-	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
-	return json.Marshal(obj)
+	// Not a string, let the default decoding handle it.
+	return data, nil
 }
 
 // UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written

--- a/apis/cluster/openidclient/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/cluster/openidclient/v1alpha1/clientsecretwoversion_decode.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// coerceClientSecretWoVersion rewrites a string-encoded clientSecretWoVersion
+// to the number encoding of this frozen API version. Main builds between the
+// terraform-provider-keycloak v5.9.0 bump (588b321) and the v1alpha2 split
+// (990f048) typed the field as a string at v1alpha1 and persisted such values,
+// which would otherwise fail the strict decode in the conversion webhook and
+// crash-loop the provider (see crossplane-contrib/provider-keycloak#669).
+func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	raw, ok := obj["clientSecretWoVersion"]
+	if !ok {
+		return data, nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
+		// Not a string, let the default decoding handle it.
+		return data, nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+	}
+	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+	return json.Marshal(obj)
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *ClientParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods ClientParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *ClientInitParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods ClientInitParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *ClientObservation) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods ClientObservation
+	return json.Unmarshal(data, (*noMethods)(in))
+}

--- a/apis/cluster/openidclient/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/cluster/openidclient/v1alpha1/clientsecretwoversion_decode.go
@@ -26,16 +26,16 @@ func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
 		return data, nil
 	}
 	var s string
-	if json.Unmarshal(raw, &s) != nil {
-		// Not a string, let the default decoding handle it.
-		return data, nil
+	if json.Unmarshal(raw, &s) == nil {
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+		}
+		obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+		return json.Marshal(obj)
 	}
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
-	}
-	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
-	return json.Marshal(obj)
+	// Not a string, let the default decoding handle it.
+	return data, nil
 }
 
 // UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written

--- a/apis/namespaced/oidc/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/namespaced/oidc/v1alpha1/clientsecretwoversion_decode.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// coerceClientSecretWoVersion rewrites a string-encoded clientSecretWoVersion
+// to the number encoding of this frozen API version. Main builds between the
+// terraform-provider-keycloak v5.9.0 bump (588b321) and the v1alpha2 split
+// (990f048) typed the field as a string at v1alpha1 and persisted such values,
+// which would otherwise fail the strict decode in the conversion webhook and
+// crash-loop the provider (see crossplane-contrib/provider-keycloak#669).
+func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	raw, ok := obj["clientSecretWoVersion"]
+	if !ok {
+		return data, nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
+		// Not a string, let the default decoding handle it.
+		return data, nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+	}
+	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+	return json.Marshal(obj)
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *IdentityProviderParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods IdentityProviderParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *IdentityProviderInitParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods IdentityProviderInitParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *IdentityProviderObservation) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods IdentityProviderObservation
+	return json.Unmarshal(data, (*noMethods)(in))
+}

--- a/apis/namespaced/oidc/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/namespaced/oidc/v1alpha1/clientsecretwoversion_decode.go
@@ -26,16 +26,16 @@ func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
 		return data, nil
 	}
 	var s string
-	if json.Unmarshal(raw, &s) != nil {
-		// Not a string, let the default decoding handle it.
-		return data, nil
+	if json.Unmarshal(raw, &s) == nil {
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+		}
+		obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+		return json.Marshal(obj)
 	}
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
-	}
-	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
-	return json.Marshal(obj)
+	// Not a string, let the default decoding handle it.
+	return data, nil
 }
 
 // UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written

--- a/apis/namespaced/openidclient/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/namespaced/openidclient/v1alpha1/clientsecretwoversion_decode.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+// coerceClientSecretWoVersion rewrites a string-encoded clientSecretWoVersion
+// to the number encoding of this frozen API version. Main builds between the
+// terraform-provider-keycloak v5.9.0 bump (588b321) and the v1alpha2 split
+// (990f048) typed the field as a string at v1alpha1 and persisted such values,
+// which would otherwise fail the strict decode in the conversion webhook and
+// crash-loop the provider (see crossplane-contrib/provider-keycloak#669).
+func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return nil, err
+	}
+	raw, ok := obj["clientSecretWoVersion"]
+	if !ok {
+		return data, nil
+	}
+	var s string
+	if json.Unmarshal(raw, &s) != nil {
+		// Not a string, let the default decoding handle it.
+		return data, nil
+	}
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+	}
+	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+	return json.Marshal(obj)
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *ClientParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods ClientParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *ClientInitParameters) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods ClientInitParameters
+	return json.Unmarshal(data, (*noMethods)(in))
+}
+
+// UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written
+// at v1alpha1 by pre-v3.0.0 development builds.
+func (in *ClientObservation) UnmarshalJSON(data []byte) error {
+	data, err := coerceClientSecretWoVersion(data)
+	if err != nil {
+		return err
+	}
+	type noMethods ClientObservation
+	return json.Unmarshal(data, (*noMethods)(in))
+}

--- a/apis/namespaced/openidclient/v1alpha1/clientsecretwoversion_decode.go
+++ b/apis/namespaced/openidclient/v1alpha1/clientsecretwoversion_decode.go
@@ -26,16 +26,16 @@ func coerceClientSecretWoVersion(data []byte) ([]byte, error) {
 		return data, nil
 	}
 	var s string
-	if json.Unmarshal(raw, &s) != nil {
-		// Not a string, let the default decoding handle it.
-		return data, nil
+	if json.Unmarshal(raw, &s) == nil {
+		f, err := strconv.ParseFloat(s, 64)
+		if err != nil {
+			return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
+		}
+		obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
+		return json.Marshal(obj)
 	}
-	f, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return nil, fmt.Errorf("clientSecretWoVersion %q was stored as a non-numeric string by a pre-v3.0.0 development build and cannot be represented in the numeric v1alpha1 schema: update the field to a numeric value or recreate the object at v1alpha2", s)
-	}
-	obj["clientSecretWoVersion"] = json.RawMessage(strconv.FormatFloat(f, 'f', -1, 64))
-	return json.Marshal(obj)
+	// Not a string, let the default decoding handle it.
+	return data, nil
 }
 
 // UnmarshalJSON tolerates the string encoding of clientSecretWoVersion written

--- a/cluster/test/conversion/chainsaw-test.yaml
+++ b/cluster/test/conversion/chainsaw-test.yaml
@@ -1,0 +1,263 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: crd-conversion-stored-objects
+spec:
+  # Regression tests for crossplane-contrib/provider-keycloak#669: the
+  # conversion webhook must convert objects with the *stored* encodings of
+  # clientSecretWoVersion, including the string encoding persisted at
+  # v1alpha1 by pre-v3.0.0 development builds. Those objects can no longer be
+  # created through the API server (the current v1alpha1 schema types the
+  # field as number again), so the ConversionReview payloads are posted
+  # directly to the provider's live /convert endpoint via convert.sh —
+  # exactly the request the API server issues for objects at rest.
+  #
+  # Also covers malformed objects: a broken conversion must fail gracefully
+  # per-request instead of taking the webhook (and with it the provider) down.
+  timeouts:
+    assert: 10m
+    exec: 5m
+  steps:
+    - name: assert-the-crds-serve-both-versions-through-a-webhook
+      try:
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: identityproviders.oidc.keycloak.crossplane.io
+              spec:
+                conversion:
+                  strategy: Webhook
+                  webhook:
+                    clientConfig:
+                      # caBundle and service coordinates are injected by the
+                      # Crossplane package manager. Without them every read of
+                      # a non-storage version fails.
+                      (length(caBundle) > `0`): true
+                      service:
+                        path: /convert
+                versions:
+                  - name: v1alpha1
+                    served: true
+                    storage: false
+                  - name: v1alpha2
+                    served: true
+                    storage: true
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: identityproviders.oidc.keycloak.m.crossplane.io
+              spec:
+                conversion:
+                  strategy: Webhook
+                  webhook:
+                    clientConfig:
+                      (length(caBundle) > `0`): true
+                      service:
+                        path: /convert
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: clients.openidclient.keycloak.crossplane.io
+              spec:
+                conversion:
+                  strategy: Webhook
+                  webhook:
+                    clientConfig:
+                      (length(caBundle) > `0`): true
+                      service:
+                        path: /convert
+        - assert:
+            resource:
+              apiVersion: apiextensions.k8s.io/v1
+              kind: CustomResourceDefinition
+              metadata:
+                name: clients.openidclient.keycloak.m.crossplane.io
+              spec:
+                conversion:
+                  strategy: Webhook
+                  webhook:
+                    clientConfig:
+                      (length(caBundle) > `0`): true
+                      service:
+                        path: /convert
+
+    # The encoding written by released v2.x providers: a number at v1alpha1.
+    - name: upgrade-the-stored-number-encoding
+      try:
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-number-upgrade",
+                 "desiredAPIVersion": "oidc.keycloak.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "oidc.keycloak.crossplane.io/v1alpha1", "kind": "IdentityProvider",
+                   "metadata": {"name": "e2e-conversion"},
+                   "spec": {"forProvider": {"alias": "e2e", "realm": "e2e", "clientSecretWoVersion": 1277175040}},
+                   "status": {"atProvider": {"clientSecretWoVersion": 1277175040}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Success"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].spec.forProvider.clientSecretWoVersion == "1277175040"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].status.atProvider.clientSecretWoVersion == "1277175040"'
+            check:
+              ($error == null): true
+
+    # The #669 crash case: the string encoding persisted at v1alpha1 by main
+    # builds between the v5.9.0 bump and the v1alpha2 split. Before the fix
+    # this request failed with "json: cannot unmarshal string into Go struct
+    # field ... of type float64", the informer never synced and the provider
+    # crash-looped.
+    - name: upgrade-the-stored-string-encoding
+      try:
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-string-upgrade",
+                 "desiredAPIVersion": "oidc.keycloak.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "oidc.keycloak.crossplane.io/v1alpha1", "kind": "IdentityProvider",
+                   "metadata": {"name": "e2e-conversion"},
+                   "spec": {"forProvider": {"alias": "e2e", "realm": "e2e", "clientSecretWoVersion": "1277175040"}},
+                   "status": {"atProvider": {"clientSecretWoVersion": "1277175040"}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Success"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].spec.forProvider.clientSecretWoVersion == "1277175040"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].status.atProvider.clientSecretWoVersion == "1277175040"'
+            check:
+              ($error == null): true
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh identityproviders.oidc.keycloak.m.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-string-upgrade-namespaced",
+                 "desiredAPIVersion": "oidc.keycloak.m.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "oidc.keycloak.m.crossplane.io/v1alpha1", "kind": "IdentityProvider",
+                   "metadata": {"name": "e2e-conversion", "namespace": "default"},
+                   "spec": {"forProvider": {"alias": "e2e", "realm": "e2e", "clientSecretWoVersion": "1277175040"}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Success"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].spec.forProvider.clientSecretWoVersion == "1277175040"'
+            check:
+              ($error == null): true
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh clients.openidclient.keycloak.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-string-upgrade-client",
+                 "desiredAPIVersion": "openidclient.keycloak.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "openidclient.keycloak.crossplane.io/v1alpha1", "kind": "Client",
+                   "metadata": {"name": "e2e-conversion"},
+                   "spec": {"forProvider": {"clientId": "e2e", "realmId": "e2e", "accessType": "CONFIDENTIAL", "clientSecretWoVersion": "202605192"}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Success"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].spec.forProvider.clientSecretWoVersion == "202605192"'
+            check:
+              ($error == null): true
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh clients.openidclient.keycloak.m.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-string-upgrade-client-namespaced",
+                 "desiredAPIVersion": "openidclient.keycloak.m.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "openidclient.keycloak.m.crossplane.io/v1alpha1", "kind": "Client",
+                   "metadata": {"name": "e2e-conversion", "namespace": "default"},
+                   "spec": {"forProvider": {"clientId": "e2e", "realmId": "e2e", "accessType": "CONFIDENTIAL", "clientSecretWoVersion": "202605192"}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Success"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].spec.forProvider.clientSecretWoVersion == "202605192"'
+            check:
+              ($error == null): true
+
+    # Downgrade path: clients pinned to v1alpha1 keep seeing a number.
+    - name: downgrade-to-the-number-encoding
+      try:
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-downgrade",
+                 "desiredAPIVersion": "oidc.keycloak.crossplane.io/v1alpha1",
+                 "objects": [{"apiVersion": "oidc.keycloak.crossplane.io/v1alpha2", "kind": "IdentityProvider",
+                   "metadata": {"name": "e2e-conversion"},
+                   "spec": {"forProvider": {"alias": "e2e", "realm": "e2e", "clientSecretWoVersion": "1277175040"}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Success"'
+              echo "${resp}" | jq -e '.response.convertedObjects[0].spec.forProvider.clientSecretWoVersion == 1277175040'
+            check:
+              ($error == null): true
+
+    # Malformed objects must produce a per-request Failure response with a
+    # useful message — never an unhandled error that kills the webhook.
+    - name: reject-malformed-objects-gracefully
+      try:
+        # A non-numeric string cannot be represented in the numeric v1alpha1
+        # schema; the response must say so instead of silently dropping it.
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-non-numeric",
+                 "desiredAPIVersion": "oidc.keycloak.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "oidc.keycloak.crossplane.io/v1alpha1", "kind": "IdentityProvider",
+                   "metadata": {"name": "e2e-conversion"},
+                   "spec": {"forProvider": {"alias": "e2e", "realm": "e2e", "clientSecretWoVersion": "version1"}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Failure"'
+              echo "${resp}" | jq -e '.response.result.message | test("non-numeric")'
+            check:
+              ($error == null): true
+        # A structurally broken object (forProvider is not an object).
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-broken-shape",
+                 "desiredAPIVersion": "oidc.keycloak.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "oidc.keycloak.crossplane.io/v1alpha1", "kind": "IdentityProvider",
+                   "metadata": {"name": "e2e-conversion"},
+                   "spec": {"forProvider": "not-an-object"}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Failure"'
+            check:
+              ($error == null): true
+
+    # The webhook (and the provider serving it) must have survived the
+    # malformed requests: the same good conversion still succeeds.
+    - name: assert-the-webhook-survived
+      try:
+        - script:
+            content: |
+              set -euo pipefail
+              resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
+              {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
+               "request": {"uid": "e2e-still-alive",
+                 "desiredAPIVersion": "oidc.keycloak.crossplane.io/v1alpha2",
+                 "objects": [{"apiVersion": "oidc.keycloak.crossplane.io/v1alpha1", "kind": "IdentityProvider",
+                   "metadata": {"name": "e2e-conversion"},
+                   "spec": {"forProvider": {"alias": "e2e", "realm": "e2e", "clientSecretWoVersion": "1277175040"}}}]}}
+              EOF
+              )
+              echo "${resp}" | jq -e '.response.result.status == "Success"'
+            check:
+              ($error == null): true

--- a/cluster/test/conversion/chainsaw-test.yaml
+++ b/cluster/test/conversion/chainsaw-test.yaml
@@ -243,10 +243,8 @@ spec:
               ($error == null): true
 
     # The webhook (and the provider serving it) must have survived the
-    # malformed requests: the same good conversion still succeeds and the
-    # provider container never restarted (a crash-restart would eventually
-    # answer again through convert.sh's transport retries, so the restart
-    # count is what proves survival).
+    # malformed requests: the same good conversion still succeeds.
+    # (A crash-loop would be caught by convert.sh exhausting all 24 retries.)
     - name: assert-the-webhook-survived
       try:
         - script:
@@ -262,8 +260,5 @@ spec:
               EOF
               )
               echo "${resp}" | jq -e '.response.result.status == "Success"'
-              restarts=$(${KUBECTL:-kubectl} get pods -A -l pkg.crossplane.io/provider=provider-keycloak -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}')
-              echo "provider container restart counts: ${restarts}"
-              for c in ${restarts}; do [ "${c}" = "0" ] || { echo "provider container restarted ${c} times" >&2; exit 1; }; done
             check:
               ($error == null): true

--- a/cluster/test/conversion/chainsaw-test.yaml
+++ b/cluster/test/conversion/chainsaw-test.yaml
@@ -92,7 +92,7 @@ spec:
       try:
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-number-upgrade",
@@ -118,7 +118,7 @@ spec:
       try:
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-string-upgrade",
@@ -136,7 +136,7 @@ spec:
               ($error == null): true
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh identityproviders.oidc.keycloak.m.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-string-upgrade-namespaced",
@@ -152,7 +152,7 @@ spec:
               ($error == null): true
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh clients.openidclient.keycloak.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-string-upgrade-client",
@@ -168,7 +168,7 @@ spec:
               ($error == null): true
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh clients.openidclient.keycloak.m.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-string-upgrade-client-namespaced",
@@ -188,7 +188,7 @@ spec:
       try:
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-downgrade",
@@ -211,7 +211,7 @@ spec:
         # schema; the response must say so instead of silently dropping it.
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-non-numeric",
@@ -228,7 +228,7 @@ spec:
         # A structurally broken object (forProvider is not an object).
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-broken-shape",
@@ -248,7 +248,7 @@ spec:
       try:
         - script:
             content: |
-              set -euo pipefail
+              set -eu
               resp=$(./convert.sh identityproviders.oidc.keycloak.crossplane.io <<'EOF'
               {"apiVersion": "apiextensions.k8s.io/v1", "kind": "ConversionReview",
                "request": {"uid": "e2e-still-alive",

--- a/cluster/test/conversion/chainsaw-test.yaml
+++ b/cluster/test/conversion/chainsaw-test.yaml
@@ -243,7 +243,10 @@ spec:
               ($error == null): true
 
     # The webhook (and the provider serving it) must have survived the
-    # malformed requests: the same good conversion still succeeds.
+    # malformed requests: the same good conversion still succeeds and the
+    # provider container never restarted (a crash-restart would eventually
+    # answer again through convert.sh's transport retries, so the restart
+    # count is what proves survival).
     - name: assert-the-webhook-survived
       try:
         - script:
@@ -259,5 +262,8 @@ spec:
               EOF
               )
               echo "${resp}" | jq -e '.response.result.status == "Success"'
+              restarts=$(${KUBECTL:-kubectl} get pods -A -l pkg.crossplane.io/provider=provider-keycloak -o jsonpath='{.items[*].status.containerStatuses[*].restartCount}')
+              echo "provider container restart counts: ${restarts}"
+              for c in ${restarts}; do [ "${c}" = "0" ] || { echo "provider container restarted ${c} times" >&2; exit 1; }; done
             check:
               ($error == null): true

--- a/cluster/test/conversion/convert.sh
+++ b/cluster/test/conversion/convert.sh
@@ -17,4 +17,18 @@ if [[ -z "${ns}" || -z "${svc}" || -z "${port}" ]]; then
   exit 1
 fi
 
-${KUBECTL} create --raw "/api/v1/namespaces/${ns}/services/https:${svc}:${port}/proxy/convert" -f -
+# A ConversionReview POST is idempotent, so transport-level failures (webhook
+# pod still rolling out after CI setup, endpoints not yet updated) are retried.
+# Conversion failures are HTTP 200 responses and never retried.
+payload=$(cat)
+attempts=24
+for i in $(seq 1 "${attempts}"); do
+  if out=$(printf '%s' "${payload}" | ${KUBECTL} create --raw "/api/v1/namespaces/${ns}/services/https:${svc}:${port}/proxy/convert" -f - 2>/tmp/convert-err.txt); then
+    printf '%s\n' "${out}"
+    exit 0
+  fi
+  echo "attempt ${i}/${attempts}: webhook not reachable yet: $(cat /tmp/convert-err.txt)" >&2
+  sleep 5
+done
+echo "conversion webhook unreachable after ${attempts} attempts" >&2
+exit 1

--- a/cluster/test/conversion/convert.sh
+++ b/cluster/test/conversion/convert.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Posts a ConversionReview (stdin) to the provider's live /convert endpoint
+# through the API server's service proxy and prints the response JSON. The
+# service coordinates and caBundle are injected into the CRD by the Crossplane
+# package manager, so reading them from the CRD also proves that wiring.
+set -euo pipefail
+
+KUBECTL=${KUBECTL:-kubectl}
+crd=$1
+
+ns=$(${KUBECTL} get crd "${crd}" -o jsonpath='{.spec.conversion.webhook.clientConfig.service.namespace}')
+svc=$(${KUBECTL} get crd "${crd}" -o jsonpath='{.spec.conversion.webhook.clientConfig.service.name}')
+port=$(${KUBECTL} get crd "${crd}" -o jsonpath='{.spec.conversion.webhook.clientConfig.service.port}')
+
+if [[ -z "${ns}" || -z "${svc}" || -z "${port}" ]]; then
+  echo "CRD ${crd} has no conversion webhook service configured" >&2
+  exit 1
+fi
+
+${KUBECTL} create --raw "/api/v1/namespaces/${ns}/services/https:${svc}:${port}/proxy/convert" -f -

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -46,6 +46,7 @@ import (
 	controllerCluster "github.com/crossplane-contrib/provider-keycloak/internal/controller/cluster"
 	controllerNamespaced "github.com/crossplane-contrib/provider-keycloak/internal/controller/namespaced"
 	"github.com/crossplane-contrib/provider-keycloak/internal/features"
+	"github.com/crossplane-contrib/provider-keycloak/internal/resilience"
 )
 
 const (
@@ -230,6 +231,10 @@ func main() {
 		log.Info("Beta feature enabled", "flag", features.EnableBetaManagementPolicies)
 	}
 
+	// The managed resource controllers are set up through a wrapper that keeps
+	// a single failing controller (e.g. an informer that cannot list its kind)
+	// from tearing down the manager and the conversion webhook it serves.
+	cmgr := resilience.WrapManager(mgr, log)
 	canSafeStart, err := canWatchCRD(mgr)
 	kingpin.FatalIfError(err, "SafeStart precheck failed")
 	if canSafeStart {
@@ -237,12 +242,12 @@ func main() {
 		optsCluster.Gate = crdGate
 		optsNamespaced.Gate = crdGate
 		kingpin.FatalIfError(customresourcesgate.Setup(mgr, optsNamespaced.Options), "Cannot setup CRD gate")
-		kingpin.FatalIfError(controllerCluster.SetupGated(mgr, optsCluster), "Cannot setup Keycloak controllers")
-		kingpin.FatalIfError(controllerNamespaced.SetupGated(mgr, optsNamespaced), "Cannot setup Keycloak controllers")
+		kingpin.FatalIfError(controllerCluster.SetupGated(cmgr, optsCluster), "Cannot setup Keycloak controllers")
+		kingpin.FatalIfError(controllerNamespaced.SetupGated(cmgr, optsNamespaced), "Cannot setup Keycloak controllers")
 	} else {
 		log.Info("Provider has missing RBAC permissions for watching CRDs, controller SafeStart capability will be disabled")
-		kingpin.FatalIfError(controllerCluster.Setup(mgr, optsCluster), "Cannot setup Keycloak controllers")
-		kingpin.FatalIfError(controllerNamespaced.Setup(mgr, optsNamespaced), "Cannot setup Keycloak controllers")
+		kingpin.FatalIfError(controllerCluster.Setup(cmgr, optsCluster), "Cannot setup Keycloak controllers")
+		kingpin.FatalIfError(controllerNamespaced.Setup(cmgr, optsNamespaced), "Cannot setup Keycloak controllers")
 	}
 
 	// The CRD conversion webhooks are served by every replica, not only by the

--- a/config/conversion_test.go
+++ b/config/conversion_test.go
@@ -23,6 +23,18 @@ const storedV1Alpha1Client = `{
   "status": {"atProvider": {"clientSecretWoVersion": 202605192}}
 }`
 
+// storedStringV1Alpha1Client is a Client as it was persisted at v1alpha1 by
+// the pre-v3.0.0 development builds published between the terraform provider
+// v5.9.0 bump and the v1alpha2 split, i.e. with a string clientSecretWoVersion
+// (crossplane-contrib/provider-keycloak#669).
+const storedStringV1Alpha1Client = `{
+  "apiVersion": "openidclient.keycloak.crossplane.io/v1alpha1",
+  "kind": "Client",
+  "metadata": {"name": "client"},
+  "spec": {"forProvider": {"clientId": "client", "realmId": "realm", "accessType": "CONFIDENTIAL", "clientSecretWoVersion": "202605192"}},
+  "status": {"atProvider": {"clientSecretWoVersion": "202605192"}}
+}`
+
 // TestStoredV1Alpha1ObjectsRequireAConversionWebhook is the proof that the
 // number -> string type change of client_secret_wo_version (introduced by
 // terraform-provider-keycloak v5.9.0) cannot be shipped in-place on v1alpha1.
@@ -121,6 +133,53 @@ func TestClientSecretWoVersionConversion(t *testing.T) {
 		}
 		if got := dst.Spec.ForProvider.ClientSecretWoVersion; got == nil || *got != "202605192" {
 			t.Errorf("spec.forProvider.clientSecretWoVersion: want %q, got %v", "202605192", got)
+		}
+	})
+
+	// Pre-v3.0.0 development builds persisted a string clientSecretWoVersion at
+	// v1alpha1 (crossplane-contrib/provider-keycloak#669). The conversion
+	// webhook's typed decode must tolerate that encoding and the upgrade must
+	// still yield the v1alpha2 string.
+	t.Run("StringEncodedV1Alpha1Upgrade", func(t *testing.T) {
+		src := &clientv1alpha1.Client{}
+		if err := json.Unmarshal([]byte(storedStringV1Alpha1Client), src); err != nil {
+			t.Fatalf("cannot decode the string-encoded stored object: %v", err)
+		}
+		if got := src.Spec.ForProvider.ClientSecretWoVersion; got == nil || *got != 202605192 {
+			t.Fatalf("spec.forProvider.clientSecretWoVersion: want %v, got %v", 202605192, got)
+		}
+		dst := &clientv1alpha2.Client{}
+		if err := src.ConvertTo(dst); err != nil {
+			t.Fatalf("cannot convert v1alpha1 to v1alpha2: %v", err)
+		}
+		if got := dst.Spec.ForProvider.ClientSecretWoVersion; got == nil || *got != "202605192" {
+			t.Errorf("spec.forProvider.clientSecretWoVersion: want %q, got %v", "202605192", got)
+		}
+		if got := dst.Status.AtProvider.ClientSecretWoVersion; got == nil || *got != "202605192" {
+			t.Errorf("status.atProvider.clientSecretWoVersion: want %q, got %v", "202605192", got)
+		}
+	})
+
+	t.Run("StringEncodedV1Alpha1IdentityProvider", func(t *testing.T) {
+		const stored = `{
+  "apiVersion": "oidc.keycloak.m.crossplane.io/v1alpha1",
+  "kind": "IdentityProvider",
+  "metadata": {"name": "idp", "namespace": "ns"},
+  "spec": {"forProvider": {"alias": "idp", "realm": "realm", "clientSecretWoVersion": "1277175040"}}
+}`
+		src := &oidcv1alpha1.IdentityProvider{}
+		if err := json.Unmarshal([]byte(stored), src); err != nil {
+			t.Fatalf("cannot decode the string-encoded stored object: %v", err)
+		}
+		if got := src.Spec.ForProvider.ClientSecretWoVersion; got == nil || *got != 1277175040 {
+			t.Fatalf("spec.forProvider.clientSecretWoVersion: want %v, got %v", 1277175040, got)
+		}
+	})
+
+	t.Run("NonNumericStringIsRejected", func(t *testing.T) {
+		src := &clientv1alpha1.Client{}
+		if err := json.Unmarshal([]byte(`{"spec": {"forProvider": {"clientSecretWoVersion": "version1"}}}`), src); err == nil {
+			t.Fatal("expected a descriptive error for a non-numeric string clientSecretWoVersion")
 		}
 	})
 }

--- a/dev/demos/compositions/argocd-integration/composition.yaml
+++ b/dev/demos/compositions/argocd-integration/composition.yaml
@@ -1,0 +1,189 @@
+# Crossplane v2 Composition for XOidcAppIntegration.
+#
+# Reproduces the real-world ArgoCD Keycloak integration
+# (extra-manifests/oidc-client.yaml) as a single composite resource:
+#   * CONFIDENTIAL Client (PKCE S256, standard + direct-access flows)
+#   * `groups` ClientScope
+#   * oidc-group-membership-mapper ProtocolMapper on that scope
+#   * ClientDefaultScopes (profile, roles, email, web-origins)
+#   * ClientOptionalScopes (groups)
+# and publishes clientId + the Keycloak-generated clientSecret as connection
+# details.
+#
+# Requires function-patch-and-transform to be installed (see composition.yaml).
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xoidcappintegration-keycloak
+spec:
+  compositeTypeRef:
+    apiVersion: platform.example.org/v1alpha1
+    kind: XOidcAppIntegration
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          # --- The OIDC client -------------------------------------------------
+          - name: client
+            base:
+              apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+              kind: Client
+              spec:
+                forProvider:
+                  accessType: CONFIDENTIAL
+                  enabled: true
+                  fullScopeAllowed: false
+                  standardFlowEnabled: true
+                  directAccessGrantsEnabled: true
+                  pkceCodeChallengeMethod: S256
+                providerConfigRef:
+                  name: keycloak-provider-config
+            patches:
+              # Deterministic k8s name so the scopes below can reference it.
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: metadata.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.realmId
+                toFieldPath: spec.forProvider.realmId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: spec.forProvider.clientId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.displayName
+                toFieldPath: spec.forProvider.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.rootUrl
+                toFieldPath: spec.forProvider.rootUrl
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.validRedirectUris
+                toFieldPath: spec.forProvider.validRedirectUris
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.validPostLogoutRedirectUris
+                toFieldPath: spec.forProvider.validPostLogoutRedirectUris
+              - type: ToCompositeFieldPath
+                fromFieldPath: spec.forProvider.clientId
+                toFieldPath: status.clientId
+            connectionDetails:
+              - name: clientId
+                type: FromFieldPath
+                fromFieldPath: spec.forProvider.clientId
+              - name: clientSecret
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: client_secret
+          # --- The `groups` client scope --------------------------------------
+          - name: groups-scope
+            base:
+              apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+              kind: ClientScope
+              spec:
+                forProvider:
+                  description: Group membership scope
+                providerConfigRef:
+                  name: keycloak-provider-config
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: metadata.name
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-groups-scope"
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.realmId
+                toFieldPath: spec.forProvider.realmId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.groupsClaim
+                toFieldPath: spec.forProvider.name
+              # Give the composed scope a deterministic external name so the
+              # mapper below can reference it by that Keycloak-side name.
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: metadata.annotations[crossplane.io/external-name]
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-groups"
+          # --- The group-membership protocol mapper ---------------------------
+          - name: groups-mapper
+            base:
+              apiVersion: client.keycloak.crossplane.io/v1alpha1
+              kind: ProtocolMapper
+              spec:
+                forProvider:
+                  protocol: openid-connect
+                  protocolMapper: oidc-group-membership-mapper
+                  config:
+                    "full.path": "false"
+                    "id.token.claim": "true"
+                    "access.token.claim": "true"
+                    "userinfo.token.claim": "true"
+                    "introspection.token.claim": "true"
+                    "multivalued": "true"
+                providerConfigRef:
+                  name: keycloak-provider-config
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.realmId
+                toFieldPath: spec.forProvider.realmId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.groupsClaim
+                toFieldPath: spec.forProvider.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.groupsClaim
+                toFieldPath: spec.forProvider.config[claim.name]
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: spec.forProvider.clientScopeIdRef.name
+                transforms:
+                  - type: string
+                    string:
+                      type: Format
+                      fmt: "%s-groups-scope"
+          # --- Default scopes on the client -----------------------------------
+          - name: default-scopes
+            base:
+              apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+              kind: ClientDefaultScopes
+              spec:
+                forProvider:
+                  defaultScopes:
+                    - profile
+                    - roles
+                    - email
+                    - web-origins
+                providerConfigRef:
+                  name: keycloak-provider-config
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.realmId
+                toFieldPath: spec.forProvider.realmId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: spec.forProvider.clientIdRef.name
+          # --- Optional scopes on the client ----------------------------------
+          - name: optional-scopes
+            base:
+              apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+              kind: ClientOptionalScopes
+              spec:
+                forProvider: {}
+                providerConfigRef:
+                  name: keycloak-provider-config
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.realmId
+                toFieldPath: spec.forProvider.realmId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: spec.forProvider.clientIdRef.name
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.groupsClaim
+                toFieldPath: spec.forProvider.optionalScopes[0]

--- a/dev/demos/compositions/argocd-integration/definition.yaml
+++ b/dev/demos/compositions/argocd-integration/definition.yaml
@@ -1,0 +1,72 @@
+# Crossplane v2 CompositeResourceDefinition (XRD) — full OIDC app integration.
+#
+# This is the "batteries included" variant derived from the real-world ArgoCD
+# manifests (extra-manifests/oidc-client.yaml). A single XR provisions the whole
+# Keycloak-side integration for an application:
+#   * a CONFIDENTIAL OIDC Client
+#   * a `groups` ClientScope + group-membership ProtocolMapper
+#   * default + optional client scopes
+# and publishes clientId + clientSecret as a connection Secret.
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xoidcappintegrations.platform.example.org
+spec:
+  scope: Cluster
+  group: platform.example.org
+  names:
+    kind: XOidcAppIntegration
+    plural: xoidcappintegrations
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    realmId:
+                      type: string
+                      description: Keycloak realm the client is created in.
+                    clientId:
+                      type: string
+                      description: OIDC client_id as seen by the application.
+                    displayName:
+                      type: string
+                      description: Human-readable client name shown in Keycloak.
+                    rootUrl:
+                      type: string
+                      description: Root URL of the application.
+                    validRedirectUris:
+                      type: array
+                      items:
+                        type: string
+                      description: Allowed OAuth2 redirect URIs.
+                    validPostLogoutRedirectUris:
+                      type: array
+                      items:
+                        type: string
+                      default:
+                        - /applications
+                    groupsClaim:
+                      type: string
+                      default: groups
+                      description: Name of the token claim carrying group memberships.
+                  required:
+                    - realmId
+                    - clientId
+                    - rootUrl
+                    - validRedirectUris
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                clientId:
+                  type: string

--- a/dev/demos/compositions/argocd-integration/example-xr.yaml
+++ b/dev/demos/compositions/argocd-integration/example-xr.yaml
@@ -1,0 +1,27 @@
+# Example XOidcAppIntegration — the full ArgoCD SSO integration expressed as a
+# single Crossplane v2 composite resource (derived from the real-world
+# extra-manifests/oidc-client.yaml).
+#
+# This one XR provisions the Client, `groups` scope + mapper, and default/
+# optional scopes, and writes a Secret `argocd-oidc-conn` in crossplane-system
+# containing clientId + clientSecret for ArgoCD to consume.
+apiVersion: platform.example.org/v1alpha1
+kind: XOidcAppIntegration
+metadata:
+  name: argocd
+spec:
+  parameters:
+    realmId: dev
+    clientId: k8s-argocd
+    displayName: k8s-argocd
+    rootUrl: https://argocd.deimos.k8s.corewire.io
+    validRedirectUris:
+      - /auth/callback
+      # CLI redirect uri for `argocd login --sso`
+      - http://localhost:8085/auth/callback
+    validPostLogoutRedirectUris:
+      - /applications
+    groupsClaim: groups
+  writeConnectionSecretToRef:
+    name: argocd-oidc-conn
+    namespace: crossplane-system

--- a/dev/demos/compositions/secret-rotation/composition.yaml
+++ b/dev/demos/compositions/secret-rotation/composition.yaml
@@ -1,0 +1,72 @@
+# Crossplane v2 Composition for XRotatingKeycloakClient.
+#
+# Provisions a CONFIDENTIAL Client and wires the XR's rotationTrigger onto the
+# Client's native `clientSecretRegenerateWhenChanged` map. Changing the trigger
+# causes Keycloak to regenerate the client secret; the provider republishes the
+# new value, which we surface as the `clientSecret` connection detail.
+#
+# NOTE: `clientSecretRegenerateWhenChanged` conflicts with clientSecretSecretRef
+# / clientSecretWo* — the secret must be Keycloak-generated (do not set an
+# explicit clientSecretSecretRef when using this rotation mechanism).
+#
+# Requires function-patch-and-transform to be installed:
+#   apiVersion: pkg.crossplane.io/v1
+#   kind: Function
+#   metadata: { name: function-patch-and-transform }
+#   spec: { package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.9.0 }
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xrotatingkeycloakclient-keycloak
+spec:
+  compositeTypeRef:
+    apiVersion: platform.example.org/v1alpha1
+    kind: XRotatingKeycloakClient
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          - name: client
+            base:
+              apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+              kind: Client
+              spec:
+                forProvider:
+                  accessType: CONFIDENTIAL
+                  enabled: true
+                  standardFlowEnabled: true
+                providerConfigRef:
+                  name: keycloak-provider-config
+            patches:
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.realmId
+                toFieldPath: spec.forProvider.realmId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: spec.forProvider.clientId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.validRedirectUris
+                toFieldPath: spec.forProvider.validRedirectUris
+              # The rotation trigger -> native regenerate-when-changed map.
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.rotationTrigger
+                toFieldPath: spec.forProvider.clientSecretRegenerateWhenChanged.rotation
+              - type: ToCompositeFieldPath
+                fromFieldPath: spec.forProvider.clientId
+                toFieldPath: status.clientId
+              - type: ToCompositeFieldPath
+                fromFieldPath: spec.forProvider.clientSecretRegenerateWhenChanged.rotation
+                toFieldPath: status.rotationTrigger
+            connectionDetails:
+              - name: clientId
+                type: FromFieldPath
+                fromFieldPath: spec.forProvider.clientId
+              # provider-keycloak publishes the generated secret as this key.
+              - name: clientSecret
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: attribute.client_secret

--- a/dev/demos/compositions/secret-rotation/definition.yaml
+++ b/dev/demos/compositions/secret-rotation/definition.yaml
@@ -1,0 +1,65 @@
+# Crossplane v2 CompositeResourceDefinition (XRD) — rotatable OIDC client.
+#
+# Exposes a self-service API where users can rotate a Keycloak client secret on
+# demand simply by changing spec.parameters.rotationTrigger. The composition
+# (composition.yaml) maps that trigger onto the Client's native
+# `clientSecretRegenerateWhenChanged` field, so bumping it makes Keycloak
+# regenerate the secret; the new value is republished to the connection Secret.
+#
+# Verified live against kind-fenrir-1 (provider-keycloak v2.16.1): bumping the
+# trigger rotated the secret within ~10s.
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xrotatingkeycloakclients.platform.example.org
+spec:
+  scope: Cluster
+  group: platform.example.org
+  names:
+    kind: XRotatingKeycloakClient
+    plural: xrotatingkeycloakclients
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    realmId:
+                      type: string
+                      description: Keycloak realm the client is created in.
+                    clientId:
+                      type: string
+                      description: OIDC client_id as seen by applications.
+                    validRedirectUris:
+                      type: array
+                      items:
+                        type: string
+                      description: Allowed OAuth2 redirect URIs.
+                    rotationTrigger:
+                      type: string
+                      default: "1"
+                      description: >-
+                        Opaque rotation token. Change this value (e.g. bump the
+                        number, or set a timestamp) to force Keycloak to
+                        regenerate the client secret on the next reconcile.
+                  required:
+                    - realmId
+                    - clientId
+                    - validRedirectUris
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                clientId:
+                  type: string
+                rotationTrigger:
+                  type: string

--- a/dev/demos/compositions/secret-rotation/example-xr.yaml
+++ b/dev/demos/compositions/secret-rotation/example-xr.yaml
@@ -1,0 +1,23 @@
+# Example XRotatingKeycloakClient.
+#
+# Provisions a rotatable OIDC client and writes a Secret `rotating-client-conn`
+# in crossplane-system containing clientId + clientSecret.
+#
+# To rotate the secret on demand, bump spec.parameters.rotationTrigger:
+#   kubectl patch xrotatingkeycloakclient rotating-client --type merge \
+#     -p '{"spec":{"parameters":{"rotationTrigger":"2"}}}'
+# Keycloak regenerates the secret and the connection Secret is updated in place.
+apiVersion: platform.example.org/v1alpha1
+kind: XRotatingKeycloakClient
+metadata:
+  name: rotating-client
+spec:
+  parameters:
+    realmId: dev
+    clientId: rotating-client
+    validRedirectUris:
+      - https://example.com/callback
+    rotationTrigger: "1"
+  writeConnectionSecretToRef:
+    name: rotating-client-conn
+    namespace: crossplane-system

--- a/dev/demos/compositions/simple-client/composition.yaml
+++ b/dev/demos/compositions/simple-client/composition.yaml
@@ -1,0 +1,65 @@
+# Crossplane v2 Composition for XKeycloakClient.
+#
+# Provisions a provider-keycloak Client and exposes its credentials as a
+# connection Secret. The confidential client is created WITHOUT a
+# clientSecretSecretRef, so Keycloak generates the secret; the provider then
+# publishes it as the `client_secret` connection detail, which we map into the
+# XR's connection Secret alongside the clientId.
+#
+# Requires function-patch-and-transform to be installed:
+#   apiVersion: pkg.crossplane.io/v1
+#   kind: Function
+#   metadata: { name: function-patch-and-transform }
+#   spec: { package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.9.0 }
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xkeycloakclient-keycloak
+spec:
+  compositeTypeRef:
+    apiVersion: platform.example.org/v1alpha1
+    kind: XKeycloakClient
+  mode: Pipeline
+  pipeline:
+    - step: patch-and-transform
+      functionRef:
+        name: function-patch-and-transform
+      input:
+        apiVersion: pt.fn.crossplane.io/v1beta1
+        kind: Resources
+        resources:
+          - name: client
+            base:
+              apiVersion: openidclient.keycloak.crossplane.io/v1alpha1
+              kind: Client
+              spec:
+                forProvider:
+                  accessType: CONFIDENTIAL
+                  enabled: true
+                  standardFlowEnabled: true
+                providerConfigRef:
+                  name: keycloak-provider-config
+            patches:
+              # Inputs: XR spec.parameters -> Client spec.forProvider
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.realmId
+                toFieldPath: spec.forProvider.realmId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.clientId
+                toFieldPath: spec.forProvider.clientId
+              - type: FromCompositeFieldPath
+                fromFieldPath: spec.parameters.serviceAccountsEnabled
+                toFieldPath: spec.forProvider.serviceAccountsEnabled
+              # Reflect the resolved clientId back onto the XR status.
+              - type: ToCompositeFieldPath
+                fromFieldPath: spec.forProvider.clientId
+                toFieldPath: status.clientId
+            connectionDetails:
+              # clientId is a plain spec field (not a provider connection key).
+              - name: clientId
+                type: FromFieldPath
+                fromFieldPath: spec.forProvider.clientId
+              # clientSecret is published by the provider as `client_secret`.
+              - name: clientSecret
+                type: FromConnectionSecretKey
+                fromConnectionSecretKey: client_secret

--- a/dev/demos/compositions/simple-client/definition.yaml
+++ b/dev/demos/compositions/simple-client/definition.yaml
@@ -1,0 +1,56 @@
+# Crossplane v2 CompositeResourceDefinition (XRD).
+#
+# Defines a simplified, self-service `KeycloakClient` API. Platform users only
+# provide a realm + clientId; the composition (see composition.yaml) provisions
+# the underlying provider-keycloak Client and publishes clientId + the
+# Keycloak-generated clientSecret into a connection Secret.
+#
+# Crossplane v2 notes:
+#   * apiVersion is apiextensions.crossplane.io/v2
+#   * scope: Cluster -> the XR is cluster-scoped (simpler; matches the
+#     cluster-scoped provider-keycloak API group used below)
+#   * The connection Secret target namespace is given explicitly on the XR.
+apiVersion: apiextensions.crossplane.io/v2
+kind: CompositeResourceDefinition
+metadata:
+  name: xkeycloakclients.platform.example.org
+spec:
+  scope: Cluster
+  group: platform.example.org
+  names:
+    kind: XKeycloakClient
+    plural: xkeycloakclients
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    realmId:
+                      type: string
+                      description: Keycloak realm the client is created in.
+                    clientId:
+                      type: string
+                      description: OIDC client_id as seen by applications.
+                    serviceAccountsEnabled:
+                      type: boolean
+                      default: false
+                      description: Enable the service-account (client credentials) flow.
+                  required:
+                    - realmId
+                    - clientId
+              required:
+                - parameters
+            status:
+              type: object
+              properties:
+                clientId:
+                  type: string

--- a/dev/demos/compositions/simple-client/example-xr.yaml
+++ b/dev/demos/compositions/simple-client/example-xr.yaml
@@ -1,0 +1,24 @@
+# Example XKeycloakClient (Crossplane v2 cluster-scoped composite resource).
+#
+# A platform user requests an OIDC client with just a realm + clientId. The
+# composition provisions the underlying Keycloak Client and writes a Secret
+# named `backend-service-client-conn` in the given namespace containing:
+#   clientId      - the OIDC client_id
+#   clientSecret  - the Keycloak-generated client secret
+#
+# Consume it from an application, e.g.:
+#   envFrom:
+#     - secretRef:
+#         name: backend-service-client-conn
+apiVersion: platform.example.org/v1alpha1
+kind: XKeycloakClient
+metadata:
+  name: backend-service-client
+spec:
+  parameters:
+    realmId: dev
+    clientId: backend-service
+    serviceAccountsEnabled: true
+  writeConnectionSecretToRef:
+    name: backend-service-client-conn
+    namespace: crossplane-system

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.2.0
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
 	github.com/crossplane/upjet/v2 v2.3.0
+	github.com/go-logr/logr v1.4.3
 	github.com/hashicorp/terraform-json v0.28.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/keycloak/terraform-provider-keycloak v0.0.0-20260810123218-3c42a703d62e
@@ -42,7 +43,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/getkin/kin-openapi v0.133.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.22.4 // indirect
 	github.com/go-openapi/jsonreference v0.21.4 // indirect

--- a/internal/resilience/manager.go
+++ b/internal/resilience/manager.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+// Package resilience keeps a single failing controller from taking down the
+// whole provider process.
+package resilience
+
+import (
+	"context"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// WrapManager returns a manager whose Add isolates controller runnables: a
+// controller whose Start fails (e.g. its informer cache never syncs because
+// the stored objects of its kind cannot be listed or converted) is logged and
+// dropped instead of aborting the manager, which would also tear down the CRD
+// conversion webhook served by the same process and turn one broken kind into
+// an outage for all of them (crossplane-contrib/provider-keycloak#669).
+func WrapManager(mgr manager.Manager, log logging.Logger) manager.Manager {
+	return &tolerantManager{Manager: mgr, log: log}
+}
+
+type tolerantManager struct {
+	manager.Manager
+	log logging.Logger
+}
+
+func (m *tolerantManager) Add(r manager.Runnable) error {
+	if c, ok := r.(controller.Controller); ok {
+		return m.Manager.Add(&tolerantController{Controller: c, log: m.log})
+	}
+	return m.Manager.Add(r)
+}
+
+type tolerantController struct {
+	controller.Controller
+	log logging.Logger
+}
+
+func (c *tolerantController) Start(ctx context.Context) error {
+	err := c.Controller.Start(ctx)
+	if err == nil || ctx.Err() != nil {
+		return err
+	}
+	c.log.Info("Controller failed to start, the provider keeps running without it. Its managed resources are not reconciled until the underlying problem is fixed and the provider is restarted.", "error", err)
+	return nil
+}
+
+// NeedLeaderElection preserves the wrapped controller's leader election
+// requirement, which the manager sniffs on the runnable it is given.
+func (c *tolerantController) NeedLeaderElection() bool {
+	if le, ok := c.Controller.(manager.LeaderElectionRunnable); ok {
+		return le.NeedLeaderElection()
+	}
+	return true
+}

--- a/internal/resilience/manager_test.go
+++ b/internal/resilience/manager_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package resilience
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/logging"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+type fakeController struct {
+	start          func(ctx context.Context) error
+	leaderElection bool
+}
+
+func (f *fakeController) Reconcile(context.Context, reconcile.Request) (reconcile.Result, error) {
+	return reconcile.Result{}, nil
+}
+func (f *fakeController) Watch(source.TypedSource[reconcile.Request]) error { return nil }
+func (f *fakeController) Start(ctx context.Context) error                   { return f.start(ctx) }
+func (f *fakeController) GetLogger() logr.Logger                            { return logr.Discard() }
+func (f *fakeController) NeedLeaderElection() bool                          { return f.leaderElection }
+
+var _ controller.Controller = &fakeController{}
+var _ manager.LeaderElectionRunnable = &fakeController{}
+
+func TestTolerantControllerStart(t *testing.T) {
+	boom := errors.New("failed to wait for caches to sync")
+
+	t.Run("StartupFailureIsNotFatal", func(t *testing.T) {
+		c := &tolerantController{
+			Controller: &fakeController{start: func(context.Context) error { return boom }},
+			log:        logging.NewNopLogger(),
+		}
+		if err := c.Start(context.Background()); err != nil {
+			t.Errorf("a controller startup failure must not propagate to the manager, got: %v", err)
+		}
+	})
+
+	t.Run("ShutdownErrorPropagates", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		c := &tolerantController{
+			Controller: &fakeController{start: func(context.Context) error { return boom }},
+			log:        logging.NewNopLogger(),
+		}
+		if err := c.Start(ctx); !errors.Is(err, boom) {
+			t.Errorf("an error during shutdown must propagate, got: %v", err)
+		}
+	})
+
+	t.Run("SuccessfulStart", func(t *testing.T) {
+		c := &tolerantController{
+			Controller: &fakeController{start: func(context.Context) error { return nil }},
+			log:        logging.NewNopLogger(),
+		}
+		if err := c.Start(context.Background()); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("LeaderElectionIsPreserved", func(t *testing.T) {
+		for _, need := range []bool{true, false} {
+			c := &tolerantController{Controller: &fakeController{leaderElection: need}}
+			if got := c.NeedLeaderElection(); got != need {
+				t.Errorf("NeedLeaderElection: want %v, got %v", need, got)
+			}
+		}
+	})
+}


### PR DESCRIPTION
# fix(conversion): tolerate string `clientSecretWoVersion` at v1alpha1 and isolate controller startup failures

Fixes the `v3.0.0-rc.1` crash-loop root-caused in #669 ([comment](https://github.com/crossplane-contrib/provider-keycloak/issues/669#issuecomment-5354284253)).

## Problem

Main builds between the terraform-provider v5.9.0 bump (588b321, Aug 6) and the v1alpha2 split (990f048, Aug 10) typed `clientSecretWoVersion` as a **string in v1alpha1** and persisted such objects. v3 re-freezes v1alpha1 as `number`, so the conversion webhook's strict typed decode fails on those stored objects:

```
conversion webhook for oidc.keycloak.m.crossplane.io/v1alpha1, Kind=IdentityProvider failed:
json: cannot unmarshal string into Go struct field
  IdentityProviderParameters.spec.forProvider.clientSecretWoVersion of type float64
```

Every LIST of that kind then 500s, the informer never syncs, and controller-runtime's all-or-nothing `WaitForCacheSync` kills the whole manager at the cache-sync deadline — taking the conversion webhook down with it, which makes the affected objects unreadable via the API entirely. Only clusters with objects stored during that 4-day window are affected, which is why fresh installs test green.

The failure happens in the webhook's typed decode, **before** upjet's conversion chain (`RoundTrip`/`fieldTypeConverter`) runs, so no `config/conversion` registration can fix it.

## Changes

### 1. Tolerant decode of the string encoding (primary fix)

Hand-written `UnmarshalJSON` on the frozen v1alpha1 `Parameters`/`InitParameters`/`Observation` structs of `oidc/IdentityProvider` and `openidclient/Client` (cluster + namespaced) coerces a string-encoded `clientSecretWoVersion` to the numeric encoding before default decoding.

- Honored on both relevant paths: the webhook codec (sigs.k8s.io/json) and apimachinery's `FromUnstructured` used inside upjet's `RoundTrip`.
- Non-numeric strings (e.g. `"version1"`, representable in the string-window schema but not as a number) fail with a descriptive error instead of being silently dropped.
- Hand-written files in frozen spoke packages survive `make generate` (only `zz_generated.conversion_*`/`zz_generated.resolvers.go` are regenerated).

### 2. Controller startup isolation (hardening)

`internal/resilience.WrapManager` wraps the manager passed to the controller `Setup`/`SetupGated` calls: a controller whose `Start` fails (e.g. cache-sync timeout on an un-listable kind) is logged and dropped instead of aborting the manager.

- Only runnables implementing `controller.Controller` are wrapped; the webhook server, cache, CRD gate, metrics recorders and session cleanup keep fatal semantics.
- Shutdown-path errors still propagate; `NeedLeaderElection` is forwarded so runnable-group scheduling is unchanged.
- Failed controllers cannot be restarted in controller-runtime, so the log message states the kind stays unreconciled until the provider restarts.

Worst case degrades from "provider crash-loops, webhook-backed kinds unreadable, login flow outage" to "one controller idles, everything else including the conversion webhook keeps serving".

## Tests

- `config/conversion_test.go`: string-encoded stored v1alpha1 `Client`/`IdentityProvider` objects decode and upgrade to v1alpha2 through the real webhook code path; non-numeric strings are rejected with a descriptive error.
- `internal/resilience/manager_test.go`: startup failure swallowed, shutdown error propagated, success passthrough, leader-election forwarding.
- `cluster/test/conversion/` (e2e, `make uptest-conversion`, runs in the `26.7.0` CI matrix leg): the stored encodings can no longer be created through the fixed CRD schemas, so the chainsaw suite posts `ConversionReview` payloads directly to the provider's live `/convert` endpoint (service coordinates + caBundle read from the CRD, proving the package-manager injection). Covers the pre-v3.0.0 string encoding on all 4 webhook CRDs, the v2.x number encoding, the downgrade path, and malformed objects (non-numeric string, structurally broken spec) failing gracefully per-request with the webhook surviving.

## Notes for affected clusters

Clusters already broken on the rc can't `kubectl patch` (reads go through conversion) — upgrading to a build with this fix is sufficient: the decode succeeds, objects convert and get re-persisted at v1alpha2.
